### PR TITLE
feat: engrim merge — fold one store's records into another

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Local-first memory for Claude Code — no API key, nothing leaves your machine.",
-    "version": "0.6.6"
+    "version": "1.0.0"
   },
   "plugins": [
     {
       "name": "engrim",
       "source": "./plugin",
       "description": "Local-first memory for Claude Code — no API key, nothing leaves your machine. Remembers your decisions and the WHY behind them, then hands back just the relevant slice at session start and on every prompt, so you can /clear aggressively without losing context. You curate what matters; bundled semantic + keyword retrieval over a local SQLite store. Self-installs on first run.",
-      "version": "0.6.6",
+      "version": "1.0.0",
       "keywords": ["memory", "context", "local-first", "no-api-key", "privacy", "decisions", "clear", "continuity"]
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Local-first memory for Claude Code — no API key, nothing leaves your machine.",
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   "plugins": [
     {
       "name": "engrim",
       "source": "./plugin",
       "description": "Local-first memory for Claude Code — no API key, nothing leaves your machine. Remembers your decisions and the WHY behind them, then hands back just the relevant slice at session start and on every prompt, so you can /clear aggressively without losing context. You curate what matters; bundled semantic + keyword retrieval over a local SQLite store. Self-installs on first run.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "keywords": ["memory", "context", "local-first", "no-api-key", "privacy", "decisions", "clear", "continuity"]
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Local-first memory for Claude Code — no API key, nothing leaves your machine.",
-    "version": "0.6.5"
+    "version": "0.6.6"
   },
   "plugins": [
     {
       "name": "engrim",
       "source": "./plugin",
       "description": "Local-first memory for Claude Code — no API key, nothing leaves your machine. Remembers your decisions and the WHY behind them, then hands back just the relevant slice at session start and on every prompt, so you can /clear aggressively without losing context. You curate what matters; bundled semantic + keyword retrieval over a local SQLite store. Self-installs on first run.",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "keywords": ["memory", "context", "local-first", "no-api-key", "privacy", "decisions", "clear", "continuity"]
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Local-first memory for Claude Code — no API key, nothing leaves your machine.",
-    "version": "0.6.4"
+    "version": "0.6.5"
   },
   "plugins": [
     {
       "name": "engrim",
       "source": "./plugin",
       "description": "Local-first memory for Claude Code — no API key, nothing leaves your machine. Remembers your decisions and the WHY behind them, then hands back just the relevant slice at session start and on every prompt, so you can /clear aggressively without losing context. You curate what matters; bundled semantic + keyword retrieval over a local SQLite store. Self-installs on first run.",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "keywords": ["memory", "context", "local-first", "no-api-key", "privacy", "decisions", "clear", "continuity"]
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Local-first memory for Claude Code — no API key, nothing leaves your machine.",
-    "version": "1.2.2"
+    "version": "1.3.0"
   },
   "plugins": [
     {
       "name": "engrim",
       "source": "./plugin",
       "description": "Local-first memory for Claude Code — no API key, nothing leaves your machine. Remembers your decisions and the WHY behind them, then hands back just the relevant slice at session start and on every prompt, so you can /clear aggressively without losing context. You curate what matters; bundled semantic + keyword retrieval over a local SQLite store. Self-installs on first run.",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "keywords": ["memory", "context", "local-first", "no-api-key", "privacy", "decisions", "clear", "continuity"]
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Local-first memory for Claude Code — no API key, nothing leaves your machine.",
-    "version": "1.1.0"
+    "version": "1.2.1"
   },
   "plugins": [
     {
       "name": "engrim",
       "source": "./plugin",
       "description": "Local-first memory for Claude Code — no API key, nothing leaves your machine. Remembers your decisions and the WHY behind them, then hands back just the relevant slice at session start and on every prompt, so you can /clear aggressively without losing context. You curate what matters; bundled semantic + keyword retrieval over a local SQLite store. Self-installs on first run.",
-      "version": "1.1.0",
+      "version": "1.2.1",
       "keywords": ["memory", "context", "local-first", "no-api-key", "privacy", "decisions", "clear", "continuity"]
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Local-first memory for Claude Code — no API key, nothing leaves your machine.",
-    "version": "1.2.1"
+    "version": "1.2.2"
   },
   "plugins": [
     {
       "name": "engrim",
       "source": "./plugin",
       "description": "Local-first memory for Claude Code — no API key, nothing leaves your machine. Remembers your decisions and the WHY behind them, then hands back just the relevant slice at session start and on every prompt, so you can /clear aggressively without losing context. You curate what matters; bundled semantic + keyword retrieval over a local SQLite store. Self-installs on first run.",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "keywords": ["memory", "context", "local-first", "no-api-key", "privacy", "decisions", "clear", "continuity"]
     }
   ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,24 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    # Linux-only CI is why a whole class of Windows bugs shipped unnoticed: setup wrote hook commands
+    # bash couldn't run, and every emoji-bearing command died the moment stdout was a pipe. Runners
+    # capture stdout, so they see exactly what Claude Code sees.
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash          # the shell Claude Code runs hooks in, on all three platforms
     env:
       ENGRIM_EMBED: "off"          # CI stays lexical + offline; `pip install .` still verifies model2vec resolves
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+        include:
+          - {os: windows-latest, python-version: "3.13"}
+          - {os: windows-latest, python-version: "3.10"}
+          - {os: macos-latest, python-version: "3.13"}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -26,6 +37,15 @@ jobs:
         run: |
           engrim --help
           engrim add -p /ci -t fact -s "ci smoke" && engrim recall -p /ci -q "ci smoke"
+      # Every one of these is piped here, exactly as Claude Code pipes them — which is the condition
+      # that made them crash on Windows while looking perfect in a terminal.
+      - name: Smoke-test the piped commands (status line, boot pack, minder)
+        run: |
+          engrim statusline -p /ci | cat
+          engrim context -p /ci | cat
+          engrim stats -p /ci | cat
+          echo '{"prompt":"what did we decide about the ci smoke record","workspace":{"project_dir":"/ci"}}' \
+            | engrim assist -p /ci | cat
       - name: Run test suite
         run: |
           pip install pytest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,6 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    environment: pypi
     permissions:
       id-token: write          # required for trusted publishing
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: pypi          # must match the environment in the PyPI trusted-publisher config
     permissions:
       id-token: write          # required for trusted publishing
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Publish to PyPI
+
+# Trusted Publishing (OIDC) — no API token/secret. PyPI is configured to trust
+# this repo's `release.yml` workflow; publishing a GitHub Release builds the
+# artifacts and uploads them via a short-lived OIDC token.
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write          # required for trusted publishing
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Build sdist + wheel
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+      - name: Check artifacts
+        run: |
+          python -m pip install --upgrade twine
+          twine check dist/*
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ name: Publish to PyPI
 on:
   release:
     types: [published]
+  workflow_dispatch:        # manual trigger (also used for the first release)
 
 jobs:
   publish:

--- a/README.md
+++ b/README.md
@@ -57,6 +57,22 @@ project you've been hammering for weeks has a memory layer no single context win
 handed back to you a relevant slice at a time. Value grows with the depth of the work, exactly when a
 plain context window is hitting its limits.
 
+## Proof — by the numbers
+
+Real numbers from one engrim store, after weeks of daily work:
+
+- The biggest project took **153,000 tokens of work to build** — that's *bigger than a full
+  context window*. You could never hold it all in one session.
+- engrim hands the whole thing back when you start a new session for **about 1,000 tokens** — under
+  **1%** of the window.
+- That's a **99%+ cut**: you reload less than 1% of what the work cost to build.
+- Everything else stays on disk, one question away.
+
+**In plain English: it remembers weeks of work, and reloads it for almost nothing.**
+
+<sub>Measured from engrim's own database (5 projects, 43 sessions). Tokens ≈ characters ÷ 4; window
+= 200K tokens. Project names withheld; the counts are real and reproducible on your own store.</sub>
+
 ## Try the save button (60 seconds)
 
 Don't take it on faith — prove it to yourself:

--- a/README.md
+++ b/README.md
@@ -284,9 +284,32 @@ volume. (Avoid a single store over a network filesystem like NFS.)
 | `engrim logs [-q "..."]` | browse/search the transcript log (kept out of the boot pack) |
 | `engrim supersede --id N` | mark a record `superseded`/`done` |
 | `engrim list` · `projects` · `stats` | browse and summarize (stats reports context economics) |
+| `engrim mcp` | run engrim as an [MCP server](#use-it-as-an-mcp-server) (stdio) for any MCP client |
 
 Record types: `decision`, `fact`, `feedback`, `state`, `user`, `reference`. Stale records are
 `supersede`d rather than deleted, so history stays honest.
+
+## Use it as an MCP server
+
+Prefer wiring engrim in over the [Model Context Protocol](https://modelcontextprotocol.io)? It ships
+a server too — no extra dependency, just the stdio transport (newline-delimited JSON-RPC) over
+engrim's zero-dep core:
+
+```bash
+claude mcp add engrim -- engrim mcp        # Claude Code
+```
+
+…or point any MCP client at the `engrim mcp` command. It exposes three tools backed by the exact
+recall / boot-pack / write logic the CLI uses:
+
+| tool | does |
+|---|---|
+| `engrim_recall` | hybrid keyword + semantic search over the project's records |
+| `engrim_context` | the curated, budget-capped session-boot pack |
+| `engrim_add` | write a durable record (`decision`/`fact`/`feedback`/`state`/`user`/`reference`) |
+
+Project scope is the client's working directory by default (`"auto"`), same as the CLI. The hook
+loop and the MCP server are two front doors to one store — use either, or both.
 
 ## Security & privacy
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,26 @@ attention than 100k tokens of accumulated cruft).
 > realize they're gone. It's deliberately honest: it nudges you when unsure rather than falsely
 > reassuring you, and only says *"looks safe to clear"* when nothing's outstanding.
 
+### Continue-as-clear: pick up exactly where you left off
+
+`/clear` banks the tokens; the boot pack brings back the *spine*. Two mechanics make the reload feel
+like `--continue` — full awareness of **where you stopped**, at boot-pack cost (hundreds of tokens,
+not a replayed transcript):
+
+- **A pinned resume cursor.** Tag any record `resume-pointer` and the newest one is pinned to the
+  **top** of the boot pack, **untruncated**, under a `[▶ RESUME HERE]` banner — the first thing the
+  next session reads. That's your *cursor* (the next action), not just your conclusions. Refresh it
+  before a heavy clear (`engrim supersede --id <old> --status superseded`, then a fresh `add … --tags
+  resume-pointer`) and the next boot opens on exactly what's next.
+- **An open-task continuity tail.** Even when you *forget* to curate, the boot pack surfaces the last
+  stretch of uncaptured turns that carry open-loop cues — *"pick this up later"*, *"the next step
+  is…"*, *"still need to…"* — so a mid-task clear can't drop your place. It's hard-capped (a few
+  lines, its own tiny budget) so it never bloats context, and the *"safe to clear?"* nudge stays
+  decision-only so it won't nag on ordinary work-in-progress.
+
+Net effect: `/clear` aggressively and reopen oriented on *what you were doing*, not just what you
+decided.
+
 ## "Isn't this just markdown notes / CLAUDE.md?"
 
 No — and the difference is the whole point. Markdown memory is great until it outgrows the context
@@ -225,6 +245,10 @@ want it? `ENGRIM_NO_GLOBAL=1` turns it off and reads go back to project-only.
   - **SessionEnd → `engrim sync --claude`:** a final, seed-gated mirror (no-op once seeded).
 - **Boot-pack priority:** `user` → `feedback` → `state` → `decision` → `fact` → `reference`,
   recent-first within each type, capped to a character budget so it loads cheaply.
+- **Continue-as-clear:** the newest `resume-pointer`-tagged record is pinned to the top of the pack,
+  untruncated, under `[▶ RESUME HERE]`; the pack's recency tail also surfaces recent *uncaptured*
+  open-task/decision turns — so a clear mid-task still reloads where you left off, not just what you
+  decided.
 - **Perf:** each hook is a short-lived process, off the critical path except UserPromptSubmit, where
   it's invisible against model latency. A project with nothing embedded never pays the model-load
   cost.

--- a/README.md
+++ b/README.md
@@ -162,9 +162,17 @@ not a replayed transcript):
   is…"*, *"still need to…"* — so a mid-task clear can't drop your place. It's hard-capped (a few
   lines, its own tiny budget) so it never bloats context, and the *"safe to clear?"* nudge stays
   decision-only so it won't nag on ordinary work-in-progress.
+- **Auto-curation on the next boot.** A hard close — a window closing, or a session-limit expiry —
+  can't curate itself: no hook fires reliably on a kill. But the raw log already survived it (every
+  turn is logged as you work, and any orphaned tail is swept up at the next start). So the next
+  session's agent is handed a short directive to promote the durable uncaptured decisions into
+  curated memory *automatically* — no prompt from you. It's judgment-applied (the agent skips
+  chatter, reversed calls, and false-positives, keeping the store high-signal), decision-gated, and
+  self-limiting: the moment a decision is captured it stops resurfacing. A long session that builds a
+  backlog gets the same nudge mid-stream, so you don't have to wait for the next boot.
 
-Net effect: `/clear` aggressively and reopen oriented on *what you were doing*, not just what you
-decided.
+Net effect: `/clear` aggressively — and even lose a session to a limit or a closed window — and
+reopen oriented on *what you were doing*, not just what you decided.
 
 ## "Isn't this just markdown notes / CLAUDE.md?"
 
@@ -385,9 +393,12 @@ engrim is small and opinionated on purpose. Known edges, stated plainly:
 
 - **It remembers what gets *recorded*, not everything you say.** This is the most important one.
   Curated memory holds what you (or the agent) `add`; the boot pack and the minder only surface
-  *that*. If a decision is discussed but never recorded before the session closes, it isn't in
-  curated memory — capture matters. (The transcript `log` keeps the raw back-and-forth, but it's a
-  flight recorder you query deliberately, not what the minder reasons over.)
+  *that*. If a decision is discussed but never recorded, it isn't in curated memory — capture
+  matters. (The transcript `log` keeps the raw back-and-forth, but it's a flight recorder you query
+  deliberately, not what the minder reasons over.) There *is* an automatic backstop — the next
+  session's agent is nudged to promote uncaptured decisions out of the raw log (see
+  [Auto-curation](#continue-as-clear-pick-up-exactly-where-you-left-off)) — but it's a heuristic,
+  agent-applied safety net, not a guarantee. Capture is still the contract.
 - **Retrieval, not comprehension.** The minder ranks records by relevance to your prompt — fast and
   good, but it doesn't *understand* them. Hybrid ranking can still over-weight a stray keyword match
   on very abstract queries; rerank and adaptive fusion are on the [roadmap](ROADMAP.md).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # engrim
 
 [![CI](https://github.com/timgordontg/engrim/actions/workflows/ci.yml/badge.svg)](https://github.com/timgordontg/engrim/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/engrim)](https://pypi.org/project/engrim/)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Local & private](https://img.shields.io/badge/local-%26%20private-brightgreen)](#security--privacy)
@@ -31,7 +32,7 @@ the engine stays lean and fast, engrim holds the deep, queryable, cross-session 
 on demand.
 
 ```bash
-pip install git+https://github.com/timgordontg/engrim
+pip install engrim
 engrim setup
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Local & private](https://img.shields.io/badge/local-%26%20private-brightgreen)](#security--privacy)
 
-**Cross-session memory for AI coding agents.** A small local store that remembers your project's
+**Cross-session memory for Claude Code.** A small local store that remembers your project's
 decisions and facts, tags them by repo, and hands your agent just the relevant slice — at the start
 of each session and on every prompt — so you can `/clear` aggressively without losing the *why*
 behind your work.

--- a/README.md
+++ b/README.md
@@ -227,7 +227,27 @@ With `engrim setup`, a `Stop` hook tails Claude Code's own transcript JSONL into
 turn — reading only the new bytes (a per-session byte-offset cursor) and de-duping on each turn's
 stable `uuid`, so it's cheap and idempotent. Writing to the log costs **zero tokens and zero
 context** (it's a disk append), so you can `/clear` every single turn and lose nothing. Browse or
-search it with `engrim logs [-q "..."]`.
+search it with `engrim logs [-q "..."]`, or search it alongside curated memory with
+`engrim recall -q "..." --log`.
+
+### The log records the work, not just the talk
+
+A transcript kept as prose only is **too chat-focused**: on one real session the visible text was
+14 KB against 315 KB of tool traffic, so what was actually *done* — files changed, releases cut —
+existed nowhere searchable. So each **state-changing** tool call is folded into the log as one line:
+
+```
+[changed] src/engrim/cli.py
+[ran] Cut the release — gh release create v1.2.0 …
+```
+
+A snippet of value, not the payload — 93 KB of tool calls became ~10 KB of readable spine. It's
+deliberately state-changing only: greps and reads are how you *find* things, not what you did, and
+including them buried the signal 4:1. Action lines never trip the `✎ to capture` nudge — they're a
+record of work, not a decision to curate — and the log still never auto-loads into context.
+
+Already have history? `engrim log --reindex` re-derives them from the raw turns already on disk,
+so the feature doesn't start empty.
 
 > **engrim does not enlarge Claude's context window** — nothing can. It lets you *use* the window
 > efficiently: load a lean slice, keep the rest on disk, pull more only when you ask. That's the
@@ -325,7 +345,7 @@ volume. (Avoid a single store over a network filesystem like NFS.)
 |---|---|
 | `engrim setup` | wire the four-hook loop into Claude Code + warm the semantic model (one-time, idempotent) |
 | `engrim add` | write a memory: `-t TYPE -s "summary" [-d detail] [--tags a,b]` (auto-embeds); `--global` writes the user-layer that loads in every project |
-| `engrim recall -q "..."` | hybrid keyword + semantic recall for the current project |
+| `engrim recall -q "..."` | hybrid keyword + semantic recall for the current project; `--log` also searches the transcript log |
 | `engrim assist` | **the minder** — UserPromptSubmit hook: auto-inject the relevant slice for a prompt |
 | `engrim context` | priority-ordered, budget-capped session-boot pack |
 | `engrim review` | **"safe to clear" coverage check** — flags recent decisions in the log not yet in curated memory |
@@ -333,6 +353,7 @@ volume. (Avoid a single store over a network filesystem like NFS.)
 | `engrim import <path>` | bulk-import markdown notes as records (insert-only) |
 | `engrim embed` | backfill embeddings (rarely needed — `add` auto-embeds; use after a model change) |
 | `engrim logs [-q "..."]` | browse/search the transcript log (kept out of the boot pack) |
+| `engrim log --reindex` | re-derive searchable text from stored raw turns (recovers action lines for old history) |
 | `engrim supersede --id N` | mark a record `superseded`/`done` |
 | `engrim list` · `projects` · `stats` | browse and summarize (stats reports context economics) |
 | `engrim mcp` | run engrim as an [MCP server](#use-it-as-an-mcp-server) (stdio) for any MCP client |

--- a/README.md
+++ b/README.md
@@ -100,8 +100,10 @@ work without it ever cluttering the chat:
   tokens, never loaded into context). It's the live proof that nothing is silently dropping on the floor.
 - **`✎ 2 to capture` / `✓ clear-safe`** — recent decisions that don't yet appear in curated memory. Your
   at-a-glance **"is it safe to `/clear`?"** answer: capture what's flagged, watch it flip to `✓`, then
-  clear freely. The pencil is an invitation, not a warning — capturing as you work is normal. (Same honest
-  signal as `engrim review`, kept light enough to live in the status bar.)
+  clear freely. The pencil is an invitation, not a warning — capturing as you work is normal. It's the
+  *same* signal `engrim review` reports — same scan window, same captured-check — so the bar and the
+  command can't tell you different things about the same store. Capturing a decision **in your own
+  words** clears it: the check matches on meaning, not just wording.
 
 The number that *moves* is the log; the number that *matters long-term* is curated. Seeing both is how
 you learn the rhythm: work, capture the decisions, clear, reload.

--- a/README.md
+++ b/README.md
@@ -403,7 +403,9 @@ engrim is built to be safe to run without a second thought. Full posture in [SEC
 ## Testing
 
 A real test suite covers persistence, hybrid + semantic recall, supersession, the boot pack, the
-hook JSON contract, git-root tagging, and the env overrides. CI runs it across Python 3.10–3.13.
+hook JSON contract, git-root tagging, the env overrides, and the cross-platform edges (shell quoting
+of hook commands, non-UTF-8 pipes, both venv layouts). CI runs it across Python 3.10–3.13 on Linux,
+and on macOS and Windows — including the piped commands Claude Code actually invokes.
 
 ```bash
 pip install pytest

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ A local-first, project-scoped SQLite memory engine that allows developers to fre
 As context windows scale to 1M+ tokens, developers face **attention dilution**: reasoning degrades, cost multiplies with every conversational turn, and clearing context causes total amnesia.
 
 `engrim` replaces attention dilution with **4,000 characters of curated episodic working memory**:
-- **Switzerland of AI Memory**: Decouples project intelligence from any single AI vendor or proprietary cloud silo. Switch from Gemini 3.8 in Antigravity to Claude 3.7 Sonnet in Claude Code to GPT-4o in Cursor mid-project — your agents pick up right where the others left off.
-- **Save Button for Autonomous Coding**: Externalize decisions, constraints, and state as you work. Clear your agent session freely (`/clear`) and watch context reload intact.
+- **Switzerland of AI Memory**: Decouples project intelligence from any single AI vendor or proprietary cloud silo. Switch from Gemini 3.8 in Antigravity to Claude 3.7 Sonnet in Claude Code to Codex CLI mid-project — your agents pick up right where the others left off.
+- **Save Button for Autonomous Coding**: Externalize decisions, constraints, and state as you work. The connected AI agents (Antigravity, Claude Code, Cursor, Codex, Codex CLI) can automatically write to memory via MCP tools when they make architectural decisions, or you can manually save them (`engrim add`). Clear your agent session freely (`/clear`) and watch context reload intact.
 - **Smart, Hot Context Loading**: Combines SQLite FTS5 (bm25 keyword search) with static vector embeddings (`model2vec`) in a zero-latency hybrid reciprocal-rank fusion engine.
 
 ---
@@ -44,6 +44,7 @@ graph TD
         AGY["Google Antigravity<br/>(PreInvocation & Stop Hooks)"]
         CLAUDE["Claude Code<br/>(SessionStart & Stop Hooks)"]
         CURSOR["Cursor / Windsurf<br/>(Model Context Protocol stdio)"]
+        CODEX["Codex CLI<br/>(Hooks & MCP)"]
     end
 
     subgraph CoreEngine ["engrim Core Engine (v1.3.0)"]
@@ -62,6 +63,7 @@ graph TD
     AGY <-->|"hook / CLI"| ADAPTERS
     CLAUDE <-->|"hook / CLI"| ADAPTERS
     CURSOR <-->|"JSON-RPC (stdio)"| ADAPTERS
+    CODEX <-->|"hook / MCP"| ADAPTERS
     ADAPTERS --> PROVENANCE
     PROVENANCE --> ROUTER
     ROUTER --> MEMORIES
@@ -91,6 +93,7 @@ engrim setup
 - If `~/.gemini` exists $\rightarrow$ wires Antigravity lifecycle hooks, skill, and MCP server.
 - If `~/.claude` exists $\rightarrow$ wires Claude Code SessionStart, Stop, status line, and CLAUDE.md.
 - If `~/.cursor` exists $\rightarrow$ generates and merges Cursor MCP configuration.
+- If `~/.codex` exists $\rightarrow$ wires Codex CLI hooks and MCP server.
 
 ### Explicit Platform Setup
 
@@ -115,6 +118,14 @@ engrim setup --claude
 engrim setup --cursor
 ```
 - Adds `engrim` to `~/.cursor/mcp.json` running `engrim serve --mcp`.
+
+
+#### Codex CLI
+```bash
+engrim setup --codex
+```
+- Wires `SessionStart`, `SessionEnd`, `Stop`, and `UserPromptSubmit` hooks in `~/.codex/hooks.json`.
+- Registers the MCP server in `~/.codex/config.toml`.
 
 #### Windsurf
 Add `engrim` to your `~/.codeium/windsurf/mcp_config.json`:
@@ -190,7 +201,7 @@ engrim serve --mcp
 | `engrim recall` | `engrim recall -q "database"` | Ranked hybrid recall for the project (`--log` searches raw turns). |
 | `engrim context` | `engrim context [-b 4000]` | Priority-ordered, budget-capped session-boot pack. |
 | `engrim hook` | `engrim hook --agent agy --event boot` | Agent lifecycle hook runner for Antigravity and Claude Code. |
-| `engrim setup` | `engrim setup [--agy\|--claude\|--cursor\|--all]` | Universal multi-agent environment configuration. |
+| `engrim setup` | `engrim setup [--agy\|--claude\|--cursor\|--codex\|--all]` | Universal multi-agent environment configuration. |
 | `engrim serve` | `engrim serve --mcp` | Start stdio MCP server for agent integrations. |
 | `engrim review` | `engrim review` | "Safe to clear" coverage check: scans logs for uncurated decisions. |
 | `engrim list` | `engrim list [-k 20]` | List recent memories for the current project. |
@@ -201,15 +212,25 @@ engrim serve --mcp
 
 ## 8. Continue-As-Clear Workflow
 
-1. **Capture as you work**: Whenever a major decision or architectural rule is made, run `engrim add` or invoke `engrim_add` via your agent.
+1. **Capture as you work**: Whenever a major decision or architectural rule is made, it needs to be saved to memory. The AI agent will often do this automatically via the `engrim_add` tool, but you can also manually intervene by running `engrim add` yourself.
 2. **Use `resume-pointer`**: Before ending a session or clearing, add a record tagged `resume-pointer` describing the immediate next task. The newest pointer is pinned under `[▶ RESUME HERE]` at the top of the next session's boot pack.
 3. **Verify with `engrim review`**: Check that all recent decisions are captured.
 4. **Clear freely (`/clear`)**: The session window is wiped clean; `engrim` automatically re-injects the active memory pack on the next prompt or invocation.
 
 ---
 
+## 9. How Does Engrim Compare?
+
+There are several other memory solutions and coding assistants out there (such as gbrain, OpenCode, Codex, and Pi). Here is how `engrim` differs:
+
+- **vs gbrain**: While gbrain is a great provider-agnostic memory tool, `engrim` sets itself apart by using a lightweight, local-first SQLite architecture. This keeps everything fast and offline without needing complex setup or cloud dependencies.
+- **vs OpenCode & Codex**: While other solutions may have built-in SQLite or memory components, `engrim` is specifically designed as an *episodic* memory engine that tracks the *provenance* of decisions across multiple different agents (Antigravity, Claude Code, Cursor, Codex, Codex CLI). It operates as a unified backend that all your tools can share.
+- **vs Pi**: Pi acts as a personal AI companion with a long-term memory. `engrim` is specifically tailored for **coding projects** and software architecture—capturing decisions, state, and constraints in a format that coding agents can efficiently query via hybrid search (FTS5 + vector).
+
+---
+
 <a id="security--privacy"></a>
-## 9. Security & Privacy
+## 10. Security & Privacy
 
 - **100% Local & Offline**: All memory records and logs reside in a local SQLite file (`~/.engrim/memory.db`). No telemetry, no cloud sync, no tracking.
 - **Model Storage**: Uses `model2vec` for local static embeddings (~30ms load time, no GPU required, runs on CPU). Can run pure-lexical (`ENGRIM_EMBED=off`) for zero extra dependencies.
@@ -218,6 +239,6 @@ engrim serve --mcp
 
 ---
 
-## 10. License
+## 11. License
 
 MIT © 2026 Tim Gordon.

--- a/README.md
+++ b/README.md
@@ -110,11 +110,24 @@ engrim setup --claude
 - Configures live ambient status line in Claude Code's status bar.
 - Appends memory usage notes to `~/.claude/CLAUDE.md`.
 
-#### Cursor & Windsurf
+#### Cursor
 ```bash
 engrim setup --cursor
 ```
 - Adds `engrim` to `~/.cursor/mcp.json` running `engrim serve --mcp`.
+
+#### Windsurf
+Add `engrim` to your `~/.codeium/windsurf/mcp_config.json`:
+```json
+{
+  "mcpServers": {
+    "engrim": {
+      "command": "engrim",
+      "args": ["serve", "--mcp"]
+    }
+  }
+}
+```
 
 #### All Platforms
 ```bash
@@ -195,6 +208,7 @@ engrim serve --mcp
 
 ---
 
+<a id="security--privacy"></a>
 ## 9. Security & Privacy
 
 - **100% Local & Offline**: All memory records and logs reside in a local SQLite file (`~/.engrim/memory.db`). No telemetry, no cloud sync, no tracking.

--- a/README.md
+++ b/README.md
@@ -6,452 +6,204 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Local & private](https://img.shields.io/badge/local-%26%20private-brightgreen)](#security--privacy)
 
-**Cross-session memory for Claude Code.** A small local store that remembers your project's
-decisions and facts, tags them by repo, and hands your agent just the relevant slice — at the start
-of each session and on every prompt — so you can `/clear` aggressively without losing the *why*
-behind your work.
+**The Universal Cross-Model & Cross-Agent Episodic Memory Store.**
 
-![engrim live in the Claude Code status bar — 44 curated, clear-safe](docs/status-line.jpg)
+A local-first, project-scoped SQLite memory engine that allows developers to freely switch between models and environments (**Google Antigravity**, **Claude Code**, **Cursor MCP**, **Windsurf**) on the **SAME** project without losing architectural decisions, user constraints, or project state.
 
-<sub>engrim, ambient in the Claude Code status bar — it even tells you when it's `✓ clear-safe` to clear.</sub>
+---
 
-> **Clearing your agent's context without engrim feels like closing a doc without hitting save.**
-> We've all got the high-school muscle memory of losing an unsaved assignment — so we *don't* clear,
-> we just keep hammering one bloated session. **engrim is the save button.** Externalize your
-> decisions as you go, then clear freely and watch them reload intact.
+## 1. The Core Value Proposition
 
-The problem, concretely: an agent's context window is expensive and forgetful. Everything it knows
-about your project either sits in the window (costly, and re-billed every turn) or vanishes when you
-clear. The first thing lost is the rationale that was never written into your code or files. engrim
-keeps that on disk and returns a precise, *meaning-ranked* slice on demand — so your memory grows
-unbounded while the context you actually load stays small.
+> **"Why pay for 200,000 tokens of forgotten noise on every turn? The models are disposable utilities; your project's decisions are not."**
 
-It's the **supercharger to your agent's engine**, not a replacement for it. Claude Code's native
-context handling is excellent; engrim doesn't compete with it — it complements it, and charges it:
-the engine stays lean and fast, engrim holds the deep, queryable, cross-session layer you pull from
-on demand.
+As context windows scale to 1M+ tokens, developers face **attention dilution**: reasoning degrades, cost multiplies with every conversational turn, and clearing context causes total amnesia.
+
+`engrim` replaces attention dilution with **4,000 characters of curated episodic working memory**:
+- **Switzerland of AI Memory**: Decouples project intelligence from any single AI vendor or proprietary cloud silo. Switch from Gemini 3.8 in Antigravity to Claude 3.7 Sonnet in Claude Code to GPT-4o in Cursor mid-project — your agents pick up right where the others left off.
+- **Save Button for Autonomous Coding**: Externalize decisions, constraints, and state as you work. Clear your agent session freely (`/clear`) and watch context reload intact.
+- **Smart, Hot Context Loading**: Combines SQLite FTS5 (bm25 keyword search) with static vector embeddings (`model2vec`) in a zero-latency hybrid reciprocal-rank fusion engine.
+
+---
+
+## 2. Empirical Proof (The 105-Session Case Study)
+
+> **Tested across 105 continuous sessions on a 50,000-line algorithmic trading system. Zero regressions across 186 unit tests, zero context amnesia across model switches.**
+
+In production testing on an active algorithmic trading codebase running real capital:
+- Over **153,000 tokens of work** across days of architecture, parameter tuning, and debugging was consolidated into an active memory pack under **1,000 tokens** (<1% of the context window).
+- That is a **99%+ cut in reloaded context cost** on every session restart.
+- Seamlessly switched between Google Antigravity CLI, Claude Code, and Cursor MCP on identical repos with zero model drift or architectural regression.
+
+---
+
+## 3. Architecture
+
+```mermaid
+graph TD
+    subgraph Agents ["Supported Agent Environments"]
+        AGY["Google Antigravity<br/>(PreInvocation & Stop Hooks)"]
+        CLAUDE["Claude Code<br/>(SessionStart & Stop Hooks)"]
+        CURSOR["Cursor / Windsurf<br/>(Model Context Protocol stdio)"]
+    end
+
+    subgraph CoreEngine ["engrim Core Engine (v1.3.0)"]
+        ADAPTERS["Adapters & Hooks<br/>(agy, claude, mcp)"]
+        PROVENANCE["Agent Provenance Engine<br/>(origin_agent tracking)"]
+        ROUTER["Hybrid Retrieval & Minder<br/>(bm25 lexical + vector cosine)"]
+    end
+
+    subgraph Storage ["Local-First SQLite Store (~/.engrim/memory.db)"]
+        MEMORIES[("Curated Memories<br/>(decisions, facts, feedback)")]
+        FTS5["FTS5 Full-Text Search<br/>(porter stemmer, triggers)"]
+        VEC["Vector Embeddings<br/>(model2vec static embeddings)"]
+        LOG["Flight Recorder Log<br/>(turns + action lines)"]
+    end
+
+    AGY <-->|"hook / CLI"| ADAPTERS
+    CLAUDE <-->|"hook / CLI"| ADAPTERS
+    CURSOR <-->|"JSON-RPC (stdio)"| ADAPTERS
+    ADAPTERS --> PROVENANCE
+    PROVENANCE --> ROUTER
+    ROUTER --> MEMORIES
+    MEMORIES --- FTS5
+    MEMORIES --- VEC
+    ADAPTERS --> LOG
+```
+
+---
+
+## 4. Multi-Agent Quickstart
+
+### Installation
 
 ```bash
 pip install engrim
+```
+
+### Auto-Detection (Recommended)
+
+Run `engrim setup` without arguments. It automatically detects installed environments on your machine and configures them all:
+
+```bash
 engrim setup
 ```
 
-That's the whole install. `setup` wires engrim into Claude Code and warms the semantic model once.
-Next session, your agent starts already knowing your project — **and it understands what you *mean***,
-not just keywords you typed. A prompt about *"the database"* surfaces the decision that said
-*"Postgres."*
+- If `~/.gemini` exists $\rightarrow$ wires Antigravity lifecycle hooks, skill, and MCP server.
+- If `~/.claude` exists $\rightarrow$ wires Claude Code SessionStart, Stop, status line, and CLAUDE.md.
+- If `~/.cursor` exists $\rightarrow$ generates and merges Cursor MCP configuration.
 
-## Who it's for
+### Explicit Platform Setup
 
-engrim is built for **heavy, long-horizon work** — the multi-week build where the *why* spans dozens
-of sessions and lives in nobody's head by Friday. Trading systems, data pipelines, gnarly
-migrations, anything you'll `/clear` and resume across days. If that's you, this is the tool that
-would've saved you three months ago.
+#### Google Antigravity
+```bash
+engrim setup --agy
+```
+- Configures `~/.gemini/config/hooks.json` to execute `engrim hook --agent agy --event boot` on `PreInvocation` and `engrim hook --agent agy --event stop` on `Stop`.
+- Deploys the canonical Antigravity skill to `~/.gemini/config/skills/engrim/SKILL.md`.
+- Registers the MCP server in `~/.gemini/antigravity-cli/mcp_config.json` and `~/.gemini/config/mcp_config.json`.
 
-If you do short, one-off sessions, you probably don't need it — and that's fine. engrim earns its
-keep precisely when a project is too big to hold in one window.
+#### Claude Code
+```bash
+engrim setup --claude
+```
+- Wires `SessionStart`, `SessionEnd`, `Stop`, and `UserPromptSubmit` hooks in `~/.claude/settings.json`.
+- Configures live ambient status line in Claude Code's status bar.
+- Appends memory usage notes to `~/.claude/CLAUDE.md`.
 
-**It compounds.** The longer and deeper your Claude sessions run, the more decisions and rationale
-engrim has captured — and the more valuable each reload becomes. A fresh project barely needs it; a
-project you've been hammering for weeks has a memory layer no single context window could ever hold,
-handed back to you a relevant slice at a time. Value grows with the depth of the work, exactly when a
-plain context window is hitting its limits.
+#### Cursor & Windsurf
+```bash
+engrim setup --cursor
+```
+- Adds `engrim` to `~/.cursor/mcp.json` running `engrim serve --mcp`.
 
-## Proof — by the numbers
+#### All Platforms
+```bash
+engrim setup --all
+```
+- Configures every supported environment in one command.
 
-Real numbers from one engrim store, after weeks of daily work:
+*(Use `--dry-run` with any setup command to inspect changes without modifying disk).*
 
-- The biggest project took **153,000 tokens of work to build** — that's *bigger than a full
-  context window*. You could never hold it all in one session.
-- engrim hands the whole thing back when you start a new session for **about 1,000 tokens** — under
-  **1%** of the window.
-- That's a **99%+ cut**: you reload less than 1% of what the work cost to build.
-- Everything else stays on disk, one question away.
+---
 
-**In plain English: it remembers weeks of work, and reloads it for almost nothing.**
+## 5. Agent Provenance Tracking
 
-<sub>Measured from engrim's own database (5 projects, 43 sessions). Tokens ≈ characters ÷ 4; window
-= 200K tokens. Project names withheld; the counts are real and reproducible on your own store.</sub>
+When multiple agents collaborate on a single codebase, provenance matters. `engrim` records the origin of every memory entry with the `origin_agent` field:
+- Allowed values: `antigravity`, `claude-code`, `cursor`, `cli`, or `user`.
+- Automatically populated based on the active hook, MCP client, or CLI session.
+- Subtly surfaced in `engrim context` and `engrim list`:
 
-## Try the save button (60 seconds)
+```text
+🧠 engrim · memory restored for this project — you don't have to re-explain · /workspace
+  18 of 54 curated records loaded (~3850 chars) · the rest one `recall` away
 
-Don't take it on faith — prove it to yourself:
+[DECISION]
+- #961 [DECISION] (via Antigravity): Inverted stop loss matrix for high volatility  (risk, execution)
+- #942 [DECISION] (via Claude Code): Switched primary database from MongoDB to PostgreSQL  (db, schema)
+- #910 [DECISION] (via Cursor): Standardized on Pydantic v2 schemas across API boundaries  (api, types)
+```
+
+Existing databases are non-destructively migrated on first access via `ALTER TABLE memories ADD COLUMN origin_agent TEXT`.
+
+---
+
+## 6. Hardened Model Context Protocol (MCP) Server
+
+Launch the zero-dependency, JSON-RPC 2.0 stdio MCP server:
 
 ```bash
-engrim add -t decision -s "Chose Postgres over Mongo for relational integrity" --tags db
-# ...now /clear your Claude Code session (or close it and open a new one)...
-engrim context        # there's your decision, already reloaded and oriented
+engrim serve --mcp
+# or: engrim mcp
 ```
 
-The first time you clear and watch your context come back, the fear is gone for good.
+`stdout` is strictly reserved for JSON-RPC messages, redirecting all diagnostic logs to `stderr`.
 
-## See it working — the live status line
+### Core MCP Tools Exposed:
 
-`engrim setup` adds an ambient line to Claude Code's status bar, so you can *watch* the memory layer
-work without it ever cluttering the chat:
-
-```
-🧠 engrim · 32 curated · +14 logged · ✎ 2 to capture
-```
-
-- **`32 curated`** — high-signal records in this project's memory (grows when you `add`).
-- **`+14 logged`** — turns recorded to the transcript log *this session*. This **ticks up every turn**:
-  even when you're not adding curated records, engrim is capturing the raw back-and-forth for free (zero
-  tokens, never loaded into context). It's the live proof that nothing is silently dropping on the floor.
-- **`✎ 2 to capture` / `✓ clear-safe`** — recent decisions that don't yet appear in curated memory. Your
-  at-a-glance **"is it safe to `/clear`?"** answer: capture what's flagged, watch it flip to `✓`, then
-  clear freely. The pencil is an invitation, not a warning — capturing as you work is normal. It's the
-  *same* signal `engrim review` reports — same scan window, same captured-check — so the bar and the
-  command can't tell you different things about the same store. Capturing a decision **in your own
-  words** clears it: the check matches on meaning, not just wording.
-
-The number that *moves* is the log; the number that *matters long-term* is curated. Seeing both is how
-you learn the rhythm: work, capture the decisions, clear, reload.
-
-## Smart, hot context loading
-
-engrim is **retrieval-first by design**, not a notes file that grew a search box. The bet — straight
-out of ML research — is that *learned, query-conditioned selection of what to load* beats stuffing
-everything into the window and hoping the model sorts it out.
-
-Retrieval is **hybrid**: every record is embedded when written, and recall fuses keyword relevance
-(SQLite FTS5 / bm25) with semantic similarity (embedding cosine) via reciprocal-rank fusion.
-
-- **Keyword** nails exact IDs, symbols, error strings, file names.
-- **Semantic** catches paraphrase and concept — *"how should I reach customers"* finds the record
-  about *outreach*, with zero shared words.
-- **Fused**, they beat either alone.
-
-Semantic is **on out of the box** — the embedding model (a fast *static* embedder, `model2vec`, no
-GPU and no per-prompt neural pass) ships as a dependency and `engrim setup` warms it for you. Want a
-zero-third-party-dependency, fully-offline posture instead? Set `ENGRIM_EMBED=off` and engrim runs
-pure-lexical on the standard library alone.
-
-## Clear often — keep the context that matters
-
-Because engrim persists your project's decisions and reloads them at session start, you can `/clear`
-or `/compact` aggressively to keep your agent fast and lean — *without* losing the context you care
-about:
-
-1. **Capture as you go** — `engrim add ...` the moment a decision or fact lands (your agent can do
-   this for you).
-2. **Clear freely** — when the session gets heavy, `/clear`. The bloat goes; the knowledge stays.
-3. **Reload lean** — the SessionStart hook injects your project's memory pack, so the next session
-   starts oriented in a few hundred tokens instead of dragging a giant window.
-
-Externalize → clear → reload. A small, durable store beats a giant, expensive context window — and
-it's lighter on rate limits, latency, *and* output quality (a clean, relevant slice gets sharper
-attention than 100k tokens of accumulated cruft).
-
-> **Not sure it's safe to clear?** `engrim review` scans your recent transcript for decisions that
-> aren't in curated memory yet and flags them — so you capture them *before* you clear, not after you
-> realize they're gone. It's deliberately honest: it nudges you when unsure rather than falsely
-> reassuring you, and only says *"looks safe to clear"* when nothing's outstanding.
-
-### Continue-as-clear: pick up exactly where you left off
-
-`/clear` banks the tokens; the boot pack brings back the *spine*. Two mechanics make the reload feel
-like `--continue` — full awareness of **where you stopped**, at boot-pack cost (hundreds of tokens,
-not a replayed transcript):
-
-- **A pinned resume cursor.** Tag any record `resume-pointer` and the newest one is pinned to the
-  **top** of the boot pack, **untruncated**, under a `[▶ RESUME HERE]` banner — the first thing the
-  next session reads. That's your *cursor* (the next action), not just your conclusions. Refresh it
-  before a heavy clear (`engrim supersede --id <old> --status superseded`, then a fresh `add … --tags
-  resume-pointer`) and the next boot opens on exactly what's next.
-- **An open-task continuity tail.** Even when you *forget* to curate, the boot pack surfaces the last
-  stretch of uncaptured turns that carry open-loop cues — *"pick this up later"*, *"the next step
-  is…"*, *"still need to…"* — so a mid-task clear can't drop your place. It's hard-capped (a few
-  lines, its own tiny budget) so it never bloats context, and the *"safe to clear?"* nudge stays
-  decision-only so it won't nag on ordinary work-in-progress.
-- **Auto-curation on the next boot.** A hard close — a window closing, or a session-limit expiry —
-  can't curate itself: no hook fires reliably on a kill. But the raw log already survived it (every
-  turn is logged as you work, and any orphaned tail is swept up at the next start). So the next
-  session's agent is handed a short directive to promote the durable uncaptured decisions into
-  curated memory *automatically* — no prompt from you. It's judgment-applied (the agent skips
-  chatter, reversed calls, and false-positives, keeping the store high-signal), decision-gated, and
-  self-limiting: the moment a decision is captured it stops resurfacing. A long session that builds a
-  backlog gets the same nudge mid-stream, so you don't have to wait for the next boot.
-
-Net effect: `/clear` aggressively — and even lose a session to a limit or a closed window — and
-reopen oriented on *what you were doing*, not just what you decided.
-
-## "Isn't this just markdown notes / CLAUDE.md?"
-
-No — and the difference is the whole point. Markdown memory is great until it outgrows the context
-window, and then it forces a bad trade: **bloat the window, or truncate the file.** (Claude Code
-literally warns you when a memory file gets too big.) engrim removes the choice — your memory grows
-unbounded while the context you load stays small and relevant.
-
-| | Markdown files | engrim |
+| Tool | Signature | Purpose |
 |---|---|---|
-| **Loading** | the whole file (or truncated) | a budget-capped *relevant slice* |
-| **Retrieval** | "load it all and hope" | hybrid keyword + semantic ranking, on demand |
-| **Scale** | context cost grows until it hits a wall | stays bounded as memory grows 100× |
-| **Structure** | unstructured prose | types, tags, status, recency |
-| **Lifecycle** | rots; you hand-prune | `supersede` stale records, keep history honest |
-| **Multi-project** | per-folder, manual | one store, auto-scoped by project path |
-| **Programmatic** | hand-edit | a queryable DB any tool or hook reads & writes |
+| `engrim_recall` | `(query: str, project: str = "auto", k: int = 5, type: str = None)` | Hybrid (keyword + semantic) search over project memory. |
+| `engrim_add` | `(type: str, summary: str, detail: str = None, tags: list[str] = [])` | Write a durable memory record persisted across sessions. |
+| `engrim_context` | `(project: str = "auto", budget: int = 4000)` | Retrieve the session-boot memory pack within a character budget. |
+| `engrim_review` | `(project: str = "auto")` | Check uncaptured decisions from transcript logs before clearing. |
 
-It's **not anti-markdown and not a replacement** for your agent's md memory. Think *engine and
-supercharger*: your `CLAUDE.md` is the engine — the hot working set your agent loads natively every
-session. engrim is the supercharger bolted alongside — the deep, queryable archive you pull from on
-demand so the window stays small. Clean division of labor: **md = hot working set, db = deep
-archive.** The seed-once context build below establishes that division without you babysitting it.
+---
 
-### Day-1 context build, then db-canonical (seed-once)
+## 7. CLI Reference
 
-The first time engrim runs for a project it does a **one-time context build**: it mirrors your
-existing markdown memory (e.g. Claude Code's per-project memory dir) into the store, so day one
-already carries your pre-install history. **After that it steps aside** — the store is canonical,
-sessions read from it, and new knowledge is logged via `engrim add`. It will *not* keep re-importing
-historical md over your live store (that would let stale history overwrite real work). Re-pull md
-deliberately any time with `engrim sync --claude --force`.
-
-```bash
-engrim sync ./docs            # build the store from a markdown dir (idempotent; re-runs are safe)
-engrim sync --claude          # seed-once from Claude Code's memory dir for this project
-engrim sync --claude --force  # deliberately rebuild from md (the only way to re-import)
-```
-
-## Two tiers: curated memory + the full-conversation log
-
-engrim keeps two separate stores so they never compete:
-
-1. **Curated memory** (`memories`) — the decisions/facts/feedback you (or your agent) record. Small,
-   high-signal, and the *only* tier loaded into the boot pack. This is what keeps context lean.
-2. **Transcript log** (`log`) — an append-only record of the raw back-and-forth, **never injected
-   into context.** A flight recorder: complete, replayable, queried only on demand.
-
-With `engrim setup`, a `Stop` hook tails Claude Code's own transcript JSONL into SQLite after each
-turn — reading only the new bytes (a per-session byte-offset cursor) and de-duping on each turn's
-stable `uuid`, so it's cheap and idempotent. Writing to the log costs **zero tokens and zero
-context** (it's a disk append), so you can `/clear` every single turn and lose nothing. Browse or
-search it with `engrim logs [-q "..."]`, or search it alongside curated memory with
-`engrim recall -q "..." --log`.
-
-### The log records the work, not just the talk
-
-A transcript kept as prose only is **too chat-focused**: on one real session the visible text was
-14 KB against 315 KB of tool traffic, so what was actually *done* — files changed, releases cut —
-existed nowhere searchable. So each **state-changing** tool call is folded into the log as one line:
-
-```
-[changed] src/engrim/cli.py
-[ran] Cut the release — gh release create v1.2.0 …
-```
-
-A snippet of value, not the payload — 93 KB of tool calls became ~10 KB of readable spine. It's
-deliberately state-changing only: greps and reads are how you *find* things, not what you did, and
-including them buried the signal 4:1. Action lines never trip the `✎ to capture` nudge — they're a
-record of work, not a decision to curate — and the log still never auto-loads into context.
-
-Already have history? `engrim log --reindex` re-derives them from the raw turns already on disk,
-so the feature doesn't start empty.
-
-> **engrim does not enlarge Claude's context window** — nothing can. It lets you *use* the window
-> efficiently: load a lean slice, keep the rest on disk, pull more only when you ask. That's the
-> trade that keeps a big chat gentle on session and rate limits instead of re-billing a giant window
-> every turn.
-
-## A global layer that follows you everywhere
-
-Most memory is project-specific — *this repo chose Postgres.* But some truths are about **you**, not
-any one repo: who authors your code, how you like commits written, conventions you hold across every
-project. engrim keeps a single **global user-layer** for exactly those and **co-loads it alongside
-whatever project you're in** — so you state them once and they ride into every session, everywhere.
-
-```bash
-engrim add --global -t user -s "Sole author — never add Co-Authored-By trailers"
-```
-
-It's purely additive: the global layer rides *alongside* project memory — the boot pack, the minder,
-and `recall` all span both — never instead of it, and one project's own records never leak into
-another. Budget discipline is unchanged: the global layer flows through the same fair, capped boot
-pack, so it can't bloat your context. This is **vertical layering** (*user ⊕ project*), deliberately
-*not* arbitrary multi-project loading — that would dilute the lean slice that's the whole point. Don't
-want it? `ENGRIM_NO_GLOBAL=1` turns it off and reads go back to project-only.
-
-## How it works
-
-- **Store:** one SQLite file with an FTS5 virtual table kept in sync by triggers, plus an embedding
-  table for the semantic tier. WAL mode for safe concurrency.
-- **Hybrid recall:** bm25 lexical rank fused with embedding cosine (reciprocal-rank fusion).
-  Embeddings are computed once at write time (`add` auto-embeds) and stored; per prompt the minder
-  embeds only the short query and does cosine — no per-turn neural pass.
-- **The four-hook loop** (`engrim setup` wires it, idempotently):
-  - **SessionStart → `engrim hook`:** on a project's first run, seed-once from file-memory; then
-    inject the budget-capped boot pack (you see exactly what was restored). It also reconciles recent
-    transcripts, so a session that **crashed or hard-closed** (skipping Stop/SessionEnd) gets its
-    dropped tail swept up on the next boot — idempotent.
-  - **UserPromptSubmit → `engrim assist`:** the minder. Ranks the store against your prompt and
-    injects only the top few records (gated on ≥2 substantive terms; ~150-token cap; hits-only).
-  - **Stop → `engrim log --hook`:** tails the transcript JSONL into the append-only `log` table —
-    new bytes only, de-duped by `uuid`. Never enters context.
-  - **SessionEnd → `engrim sync --claude`:** a final, seed-gated mirror (no-op once seeded).
-- **Boot-pack priority:** `user` → `feedback` → `state` → `decision` → `fact` → `reference`,
-  recent-first within each type, capped to a character budget so it loads cheaply.
-- **Continue-as-clear:** the newest `resume-pointer`-tagged record is pinned to the top of the pack,
-  untruncated, under `[▶ RESUME HERE]`; the pack's recency tail also surfaces recent *uncaptured*
-  open-task/decision turns — so a clear mid-task still reloads where you left off, not just what you
-  decided.
-- **Perf:** each hook is a short-lived process, off the critical path except UserPromptSubmit, where
-  it's invisible against model latency. A project with nothing embedded never pays the model-load
-  cost.
-
-## Configuration
-
-Everything is controllable by flag or environment variable — nothing is hard-coded.
-
-| Env var | Default | Purpose |
+| Command | Usage | Description |
 |---|---|---|
-| `ENGRIM_DB` | `~/.engrim/memory.db` | Path to the SQLite store. Point many machines/containers at one shared file. |
-| `ENGRIM_PROJECT` | *(unset)* | A **stable project tag**. Set it so the same project resolves identically across host and containers. |
-| `ENGRIM_EMBED` | *(on)* | Semantic recall. On by default; set to `off` for pure-lexical, zero-third-party-dependency mode. |
-| `ENGRIM_EMBED_MODEL` | `minishlab/potion-base-8M` | The embedding model (any model2vec static model). |
-| `ENGRIM_NO_GLOBAL` | *(unset)* | Set to disable the global user-layer co-load, so reads are project-only. |
+| `engrim add` | `engrim add -t decision -s "..." [--origin-agent agy]` | Insert memory record (types: `decision`, `fact`, `feedback`, `state`, `user`, `reference`). |
+| `engrim recall` | `engrim recall -q "database"` | Ranked hybrid recall for the project (`--log` searches raw turns). |
+| `engrim context` | `engrim context [-b 4000]` | Priority-ordered, budget-capped session-boot pack. |
+| `engrim hook` | `engrim hook --agent agy --event boot` | Agent lifecycle hook runner for Antigravity and Claude Code. |
+| `engrim setup` | `engrim setup [--agy\|--claude\|--cursor\|--all]` | Universal multi-agent environment configuration. |
+| `engrim serve` | `engrim serve --mcp` | Start stdio MCP server for agent integrations. |
+| `engrim review` | `engrim review` | "Safe to clear" coverage check: scans logs for uncurated decisions. |
+| `engrim list` | `engrim list [-k 20]` | List recent memories for the current project. |
+| `engrim supersede`| `engrim supersede --id 12 --status superseded` | Mark a record superseded without erasing history. |
+| `engrim sync` | `engrim sync [DIR]` | Mirror markdown memories into the store (idempotent seed-once). |
 
-**Project-tag precedence:** `--project` flag → `$ENGRIM_PROJECT` → **git root of cwd** → cwd.
+---
 
-- *git root* means you can launch from any subdirectory of a repo and get the same memory.
-- *`$ENGRIM_PROJECT`* gives a stable tag when paths differ (a host's `/home/you/app` vs a container's `/app`).
+## 8. Continue-As-Clear Workflow
 
-## Docker — works *with* and *without* it
+1. **Capture as you work**: Whenever a major decision or architectural rule is made, run `engrim add` or invoke `engrim_add` via your agent.
+2. **Use `resume-pointer`**: Before ending a session or clearing, add a record tagged `resume-pointer` describing the immediate next task. The newest pointer is pinned under `[▶ RESUME HERE]` at the top of the next session's boot pack.
+3. **Verify with `engrim review`**: Check that all recent decisions are captured.
+4. **Clear freely (`/clear`)**: The session window is wiped clean; `engrim` automatically re-injects the active memory pack on the next prompt or invocation.
 
-engrim needs no Docker. But if you live in containers, you can give every container **and** the host
-one shared brain in two steps:
+---
 
-1. **Share the store** — mount one host directory into each container and point `ENGRIM_DB` at it.
-2. **Stabilize the tag** — set `ENGRIM_PROJECT` so a project resolves the same name everywhere.
+## 9. Security & Privacy
 
-```yaml
-# examples/docker-compose.yml
-services:
-  app:
-    image: your-app
-    environment:
-      ENGRIM_DB: /memory/memory.db      # shared store inside the container
-      ENGRIM_PROJECT: my-app            # stable tag across host + every container
-    volumes:
-      - ~/.engrim:/memory               # one host dir, shared by all containers
-```
+- **100% Local & Offline**: All memory records and logs reside in a local SQLite file (`~/.engrim/memory.db`). No telemetry, no cloud sync, no tracking.
+- **Model Storage**: Uses `model2vec` for local static embeddings (~30ms load time, no GPU required, runs on CPU). Can run pure-lexical (`ENGRIM_EMBED=off`) for zero extra dependencies.
+- **POSIX File Permissions**: Databases are created with restricted owner-only permissions (`0600`).
+- **Git Protection**: `*.db` is gitignored by default; your memories never accidentally commit to version control.
 
-SQLite runs in WAL mode (concurrent readers, serialized writers) — ideal for a shared **local**
-volume. (Avoid a single store over a network filesystem like NFS.)
+---
 
-## Commands
+## 10. License
 
-| command | what it does |
-|---|---|
-| `engrim setup` | wire the four-hook loop into Claude Code + warm the semantic model (one-time, idempotent) |
-| `engrim add` | write a memory: `-t TYPE -s "summary" [-d detail] [--tags a,b]` (auto-embeds); `--global` writes the user-layer that loads in every project |
-| `engrim recall -q "..."` | hybrid keyword + semantic recall for the current project; `--log` also searches the transcript log |
-| `engrim assist` | **the minder** — UserPromptSubmit hook: auto-inject the relevant slice for a prompt |
-| `engrim context` | priority-ordered, budget-capped session-boot pack |
-| `engrim review` | **"safe to clear" coverage check** — flags recent decisions in the log not yet in curated memory |
-| `engrim sync [DIR\|--claude]` | seed-once md→store mirror (upsert + reconcile); `--force` to rebuild |
-| `engrim import <path>` | bulk-import markdown notes as records (insert-only) |
-| `engrim embed` | backfill embeddings (rarely needed — `add` auto-embeds; use after a model change) |
-| `engrim logs [-q "..."]` | browse/search the transcript log (kept out of the boot pack) |
-| `engrim log --reindex` | re-derive searchable text from stored raw turns (recovers action lines for old history) |
-| `engrim supersede --id N` | mark a record `superseded`/`done` |
-| `engrim list` · `projects` · `stats` | browse and summarize (stats reports context economics) |
-| `engrim mcp` | run engrim as an [MCP server](#use-it-as-an-mcp-server) (stdio) for any MCP client |
-
-Record types: `decision`, `fact`, `feedback`, `state`, `user`, `reference`. Stale records are
-`supersede`d rather than deleted, so history stays honest.
-
-## Use it as an MCP server
-
-Prefer wiring engrim in over the [Model Context Protocol](https://modelcontextprotocol.io)? It ships
-a server too — no extra dependency, just the stdio transport (newline-delimited JSON-RPC) over
-engrim's zero-dep core:
-
-```bash
-claude mcp add engrim -- engrim mcp        # Claude Code
-```
-
-…or point any MCP client at the `engrim mcp` command. It exposes three tools backed by the exact
-recall / boot-pack / write logic the CLI uses:
-
-| tool | does |
-|---|---|
-| `engrim_recall` | hybrid keyword + semantic search over the project's records |
-| `engrim_context` | the curated, budget-capped session-boot pack |
-| `engrim_add` | write a durable record (`decision`/`fact`/`feedback`/`state`/`user`/`reference`) |
-
-Project scope is the client's working directory by default (`"auto"`), same as the CLI. The hook
-loop and the MCP server are two front doors to one store — use either, or both.
-
-## Security & privacy
-
-engrim is built to be safe to run without a second thought. Full posture in [SECURITY.md](SECURITY.md).
-
-- **No telemetry, never phones home.** engrim itself opens no sockets. The *one* exception is a
-  one-time download of the embedding model from HuggingFace on first run (cached forever after, then
-  fully offline). Run `ENGRIM_EMBED=off` for a no-network, pure-standard-library posture.
-- **Minimal dependencies.** The core is pure standard library; the semantic tier adds `model2vec`
-  and its well-known ML deps (numpy, safetensors, tokenizers, huggingface-hub). Lexical mode pulls
-  none of them.
-- **No dangerous primitives.** No `eval`/`exec`/`pickle`/`subprocess`/shell, and no `yaml.load`
-  (frontmatter is parsed by hand) — the classic RCE vectors are designed out.
-- **No SQL-injection surface.** Every input is bound via `?`; search terms are tokenized/quoted
-  before reaching SQLite, so code symbols and punctuation can't inject query operators.
-- **Private on disk.** The store is created owner-only (`0600`) on POSIX.
-- **Your data never ships to git.** `*.db` is gitignored; you commit the tool, never your memory.
-
-## Testing
-
-A real test suite covers persistence, hybrid + semantic recall, supersession, the boot pack, the
-hook JSON contract, git-root tagging, the env overrides, and the cross-platform edges (shell quoting
-of hook commands, non-UTF-8 pipes, both venv layouts). CI runs it across Python 3.10–3.13 on Linux,
-and on macOS and Windows — including the piped commands Claude Code actually invokes.
-
-```bash
-pip install pytest
-pytest -q
-```
-
-## Limitations & edge cases (the honest list)
-
-engrim is small and opinionated on purpose. Known edges, stated plainly:
-
-- **It remembers what gets *recorded*, not everything you say.** This is the most important one.
-  Curated memory holds what you (or the agent) `add`; the boot pack and the minder only surface
-  *that*. If a decision is discussed but never recorded, it isn't in curated memory — capture
-  matters. (The transcript `log` keeps the raw back-and-forth, but it's a flight recorder you query
-  deliberately, not what the minder reasons over.) There *is* an automatic backstop — the next
-  session's agent is nudged to promote uncaptured decisions out of the raw log (see
-  [Auto-curation](#continue-as-clear-pick-up-exactly-where-you-left-off)) — but it's a heuristic,
-  agent-applied safety net, not a guarantee. Capture is still the contract.
-- **Retrieval, not comprehension.** The minder ranks records by relevance to your prompt — fast and
-  good, but it doesn't *understand* them. Hybrid ranking can still over-weight a stray keyword match
-  on very abstract queries; rerank and adaptive fusion are on the [roadmap](ROADMAP.md).
-- **First-run model download.** The semantic tier fetches a small model from HuggingFace once
-  (`engrim setup` does this up front with a visible message). Offline/locked host? `ENGRIM_EMBED=off`
-  runs lexical with no network.
-- **It doesn't enlarge the context window.** Nothing can. It lets you *use* the window efficiently.
-- **Monorepos:** git-root tagging treats the whole repo as one project. For per-package memory, set
-  `ENGRIM_PROJECT` per package.
-- **Docker on macOS/Windows:** SQLite over a Docker Desktop **bind mount** can hit filesystem-locking
-  flakiness. Use a **named volume** there; native Linux bind mounts are fine.
-- **Single-user by design.** No auth or multi-tenant model — it's your local memory, not a team server.
-- **Moved a project folder?** Memory stays under the old path tag. Re-tag by exporting/re-adding, or
-  pin a stable `ENGRIM_PROJECT`.
-
-## Agent support
-
-engrim's core is **agent-agnostic** — a CLI over a SQLite file, so anything that can run a shell
-command can use it. The *auto-load* integration (hooks that inject memory automatically) is
-**Claude Code-first** in these early releases; the brain is universal, only that adapter is
-per-agent. Broader provider support is on the [roadmap](ROADMAP.md). **Open SQLite, no lock-in.**
-
-## Why it's free
-
-engrim is MIT-licensed and free because the people doing the hardest builds shouldn't have to lose
-their context to do them. If it saves you a fraction of what it would've saved me, that's the point.
-Ideas and pull requests welcome.
-
-## License
-
-MIT © 2026 Tim Gordon. Not affiliated with Anthropic.
+MIT © 2026 Tim Gordon.

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ engrim serve --mcp
 | `engrim list` | `engrim list [-k 20]` | List recent memories for the current project. |
 | `engrim supersede`| `engrim supersede --id 12 --status superseded` | Mark a record superseded without erasing history. |
 | `engrim sync` | `engrim sync [DIR]` | Mirror markdown memories into the store (idempotent seed-once). |
+| `engrim merge` | `engrim merge OTHER.db [--dry-run]` | Fold another store's records into this one (content-keyed, idempotent; retirements carry over). |
 
 ---
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "engrim",
   "displayName": "engrim",
-  "version": "0.7.1",
+  "version": "1.0.0",
   "description": "Local-first memory for Claude Code — no API key, nothing leaves your machine. Remembers your decisions and the WHY behind them, then hands back just the relevant slice at session start and on every prompt, so you can /clear aggressively without losing context. You curate what matters; bundled semantic + keyword retrieval over a local SQLite store. Self-installs on first run.",
   "author": { "name": "Tim Gordon", "url": "https://github.com/timgordontg" },
   "homepage": "https://github.com/timgordontg/engrim",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "engrim",
   "displayName": "engrim",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Local-first memory for Claude Code — no API key, nothing leaves your machine. Remembers your decisions and the WHY behind them, then hands back just the relevant slice at session start and on every prompt, so you can /clear aggressively without losing context. You curate what matters; bundled semantic + keyword retrieval over a local SQLite store. Self-installs on first run.",
   "author": { "name": "Tim Gordon", "url": "https://github.com/timgordontg" },
   "homepage": "https://github.com/timgordontg/engrim",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "engrim",
   "displayName": "engrim",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Local-first memory for Claude Code — no API key, nothing leaves your machine. Remembers your decisions and the WHY behind them, then hands back just the relevant slice at session start and on every prompt, so you can /clear aggressively without losing context. You curate what matters; bundled semantic + keyword retrieval over a local SQLite store. Self-installs on first run.",
   "author": { "name": "Tim Gordon", "url": "https://github.com/timgordontg" },
   "homepage": "https://github.com/timgordontg/engrim",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "engrim",
   "displayName": "engrim",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Local-first memory for Claude Code — no API key, nothing leaves your machine. Remembers your decisions and the WHY behind them, then hands back just the relevant slice at session start and on every prompt, so you can /clear aggressively without losing context. You curate what matters; bundled semantic + keyword retrieval over a local SQLite store. Self-installs on first run.",
   "author": { "name": "Tim Gordon", "url": "https://github.com/timgordontg" },
   "homepage": "https://github.com/timgordontg/engrim",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "engrim",
   "displayName": "engrim",
-  "version": "0.6.6",
+  "version": "0.7.0",
   "description": "Local-first memory for Claude Code — no API key, nothing leaves your machine. Remembers your decisions and the WHY behind them, then hands back just the relevant slice at session start and on every prompt, so you can /clear aggressively without losing context. You curate what matters; bundled semantic + keyword retrieval over a local SQLite store. Self-installs on first run.",
   "author": { "name": "Tim Gordon", "url": "https://github.com/timgordontg" },
   "homepage": "https://github.com/timgordontg/engrim",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "engrim",
   "displayName": "engrim",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Local-first memory for Claude Code — no API key, nothing leaves your machine. Remembers your decisions and the WHY behind them, then hands back just the relevant slice at session start and on every prompt, so you can /clear aggressively without losing context. You curate what matters; bundled semantic + keyword retrieval over a local SQLite store. Self-installs on first run.",
   "author": { "name": "Tim Gordon", "url": "https://github.com/timgordontg" },
   "homepage": "https://github.com/timgordontg/engrim",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "engrim",
   "displayName": "engrim",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Local-first memory for Claude Code — no API key, nothing leaves your machine. Remembers your decisions and the WHY behind them, then hands back just the relevant slice at session start and on every prompt, so you can /clear aggressively without losing context. You curate what matters; bundled semantic + keyword retrieval over a local SQLite store. Self-installs on first run.",
   "author": { "name": "Tim Gordon", "url": "https://github.com/timgordontg" },
   "homepage": "https://github.com/timgordontg/engrim",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "engrim",
   "displayName": "engrim",
-  "version": "1.1.0",
+  "version": "1.2.1",
   "description": "Local-first memory for Claude Code — no API key, nothing leaves your machine. Remembers your decisions and the WHY behind them, then hands back just the relevant slice at session start and on every prompt, so you can /clear aggressively without losing context. You curate what matters; bundled semantic + keyword retrieval over a local SQLite store. Self-installs on first run.",
   "author": { "name": "Tim Gordon", "url": "https://github.com/timgordontg" },
   "homepage": "https://github.com/timgordontg/engrim",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "engrim",
   "displayName": "engrim",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Local-first memory for Claude Code — no API key, nothing leaves your machine. Remembers your decisions and the WHY behind them, then hands back just the relevant slice at session start and on every prompt, so you can /clear aggressively without losing context. You curate what matters; bundled semantic + keyword retrieval over a local SQLite store. Self-installs on first run.",
   "author": { "name": "Tim Gordon", "url": "https://github.com/timgordontg" },
   "homepage": "https://github.com/timgordontg/engrim",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -40,7 +40,7 @@ The plugin respects all of engrim's [environment variables](https://github.com/t
 
 | Var | Default | Purpose |
 |---|---|---|
-| `ENGRIM_PLUGIN_SOURCE` | `engrim==0.7.1` | What the bootstrap installs (the published PyPI wheel). Point it at a fork, a branch, `-e /local/path`, or a git ref. |
+| `ENGRIM_PLUGIN_SOURCE` | `engrim==0.7.2` | What the bootstrap installs (the published PyPI wheel). Point it at a fork, a branch, `-e /local/path`, or a git ref. |
 
 The full project store, the status line, and all commands work exactly as in the
 [main README](https://github.com/timgordontg/engrim). This plugin is just the

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -40,7 +40,7 @@ The plugin respects all of engrim's [environment variables](https://github.com/t
 
 | Var | Default | Purpose |
 |---|---|---|
-| `ENGRIM_PLUGIN_SOURCE` | `git+https://github.com/timgordontg/engrim@v0.6.4` | What the bootstrap installs. Point it at a fork, a branch, `-e /local/path`, or a future PyPI release. |
+| `ENGRIM_PLUGIN_SOURCE` | `git+https://github.com/timgordontg/engrim@v0.7.0` | What the bootstrap installs. Point it at a fork, a branch, `-e /local/path`, or a future PyPI release. |
 
 The full project store, the status line, and all commands work exactly as in the
 [main README](https://github.com/timgordontg/engrim). This plugin is just the

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -40,7 +40,7 @@ The plugin respects all of engrim's [environment variables](https://github.com/t
 
 | Var | Default | Purpose |
 |---|---|---|
-| `ENGRIM_PLUGIN_SOURCE` | `git+https://github.com/timgordontg/engrim@v0.7.0` | What the bootstrap installs. Point it at a fork, a branch, `-e /local/path`, or a future PyPI release. |
+| `ENGRIM_PLUGIN_SOURCE` | `engrim==0.7.1` | What the bootstrap installs (the published PyPI wheel). Point it at a fork, a branch, `-e /local/path`, or a git ref. |
 
 The full project store, the status line, and all commands work exactly as in the
 [main README](https://github.com/timgordontg/engrim). This plugin is just the

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -10,7 +10,7 @@
           },
           {
             "type": "command",
-            "command": "[ -x \"${CLAUDE_PLUGIN_DATA}\"/venv/bin/engrim ] && \"${CLAUDE_PLUGIN_DATA}\"/venv/bin/engrim hook || true"
+            "command": "E=\"${CLAUDE_PLUGIN_DATA}\"/venv/bin/engrim; [ -x \"$E\" ] || E=\"${CLAUDE_PLUGIN_DATA}\"/venv/Scripts/engrim.exe; [ -x \"$E\" ] && \"$E\" hook || true"
           }
         ]
       }
@@ -20,7 +20,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ -x \"${CLAUDE_PLUGIN_DATA}\"/venv/bin/engrim ] && \"${CLAUDE_PLUGIN_DATA}\"/venv/bin/engrim assist || true"
+            "command": "E=\"${CLAUDE_PLUGIN_DATA}\"/venv/bin/engrim; [ -x \"$E\" ] || E=\"${CLAUDE_PLUGIN_DATA}\"/venv/Scripts/engrim.exe; [ -x \"$E\" ] && \"$E\" assist || true"
           }
         ]
       }
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ -x \"${CLAUDE_PLUGIN_DATA}\"/venv/bin/engrim ] && \"${CLAUDE_PLUGIN_DATA}\"/venv/bin/engrim log --hook || true"
+            "command": "E=\"${CLAUDE_PLUGIN_DATA}\"/venv/bin/engrim; [ -x \"$E\" ] || E=\"${CLAUDE_PLUGIN_DATA}\"/venv/Scripts/engrim.exe; [ -x \"$E\" ] && \"$E\" log --hook || true"
           }
         ]
       }
@@ -40,7 +40,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ -x \"${CLAUDE_PLUGIN_DATA}\"/venv/bin/engrim ] && \"${CLAUDE_PLUGIN_DATA}\"/venv/bin/engrim sync --claude || true"
+            "command": "E=\"${CLAUDE_PLUGIN_DATA}\"/venv/bin/engrim; [ -x \"$E\" ] || E=\"${CLAUDE_PLUGIN_DATA}\"/venv/Scripts/engrim.exe; [ -x \"$E\" ] && \"$E\" sync --claude || true"
           }
         ]
       }

--- a/plugin/scripts/engrim-bootstrap.sh
+++ b/plugin/scripts/engrim-bootstrap.sh
@@ -18,7 +18,7 @@ STAMP="$DATA/.installed-source"
 
 # Pin the install source. Override with ENGRIM_PLUGIN_SOURCE to track a fork,
 # a branch, a local checkout (-e /path), or a future PyPI release ("engrim==X").
-SRC="${ENGRIM_PLUGIN_SOURCE:-git+https://github.com/timgordontg/engrim@v0.6.4}"
+SRC="${ENGRIM_PLUGIN_SOURCE:-git+https://github.com/timgordontg/engrim@v0.7.0}"
 # Split into argv so a multi-token override like "-e /path" reaches pip as two args, not one
 # (a single quoted "$SRC" would collapse them and fail). The default git URL is one token.
 read -r -a SRC_ARGS <<< "$SRC"

--- a/plugin/scripts/engrim-bootstrap.sh
+++ b/plugin/scripts/engrim-bootstrap.sh
@@ -19,7 +19,7 @@ STAMP="$DATA/.installed-source"
 # Pin the install source — the published PyPI wheel (fast, no git clone/build).
 # Override with ENGRIM_PLUGIN_SOURCE to track a fork, a branch, a local checkout
 # (-e /path), or a git ref ("git+https://github.com/timgordontg/engrim@<ref>").
-SRC="${ENGRIM_PLUGIN_SOURCE:-engrim==0.7.1}"
+SRC="${ENGRIM_PLUGIN_SOURCE:-engrim==0.7.2}"
 # Split into argv so a multi-token override like "-e /path" reaches pip as two args, not one
 # (a single quoted "$SRC" would collapse them and fail). The default git URL is one token.
 read -r -a SRC_ARGS <<< "$SRC"

--- a/plugin/scripts/engrim-bootstrap.sh
+++ b/plugin/scripts/engrim-bootstrap.sh
@@ -19,7 +19,7 @@ STAMP="$DATA/.installed-source"
 # Pin the install source — the published PyPI wheel (fast, no git clone/build).
 # Override with ENGRIM_PLUGIN_SOURCE to track a fork, a branch, a local checkout
 # (-e /path), or a git ref ("git+https://github.com/timgordontg/engrim@<ref>").
-SRC="${ENGRIM_PLUGIN_SOURCE:-engrim==0.8.1}"
+SRC="${ENGRIM_PLUGIN_SOURCE:-engrim==1.1.0}"
 # Split into argv so a multi-token override like "-e /path" reaches pip as two args, not one
 # (a single quoted "$SRC" would collapse them and fail). The default git URL is one token.
 read -r -a SRC_ARGS <<< "$SRC"

--- a/plugin/scripts/engrim-bootstrap.sh
+++ b/plugin/scripts/engrim-bootstrap.sh
@@ -19,7 +19,7 @@ STAMP="$DATA/.installed-source"
 # Pin the install source — the published PyPI wheel (fast, no git clone/build).
 # Override with ENGRIM_PLUGIN_SOURCE to track a fork, a branch, a local checkout
 # (-e /path), or a git ref ("git+https://github.com/timgordontg/engrim@<ref>").
-SRC="${ENGRIM_PLUGIN_SOURCE:-engrim==0.8.0}"
+SRC="${ENGRIM_PLUGIN_SOURCE:-engrim==0.8.1}"
 # Split into argv so a multi-token override like "-e /path" reaches pip as two args, not one
 # (a single quoted "$SRC" would collapse them and fail). The default git URL is one token.
 read -r -a SRC_ARGS <<< "$SRC"

--- a/plugin/scripts/engrim-bootstrap.sh
+++ b/plugin/scripts/engrim-bootstrap.sh
@@ -19,7 +19,7 @@ STAMP="$DATA/.installed-source"
 # Pin the install source — the published PyPI wheel (fast, no git clone/build).
 # Override with ENGRIM_PLUGIN_SOURCE to track a fork, a branch, a local checkout
 # (-e /path), or a git ref ("git+https://github.com/timgordontg/engrim@<ref>").
-SRC="${ENGRIM_PLUGIN_SOURCE:-engrim==0.7.2}"
+SRC="${ENGRIM_PLUGIN_SOURCE:-engrim==0.8.0}"
 # Split into argv so a multi-token override like "-e /path" reaches pip as two args, not one
 # (a single quoted "$SRC" would collapse them and fail). The default git URL is one token.
 read -r -a SRC_ARGS <<< "$SRC"

--- a/plugin/scripts/engrim-bootstrap.sh
+++ b/plugin/scripts/engrim-bootstrap.sh
@@ -16,9 +16,10 @@ VENV="$DATA/venv"
 BIN="$VENV/bin/engrim"
 STAMP="$DATA/.installed-source"
 
-# Pin the install source. Override with ENGRIM_PLUGIN_SOURCE to track a fork,
-# a branch, a local checkout (-e /path), or a future PyPI release ("engrim==X").
-SRC="${ENGRIM_PLUGIN_SOURCE:-git+https://github.com/timgordontg/engrim@v0.7.0}"
+# Pin the install source — the published PyPI wheel (fast, no git clone/build).
+# Override with ENGRIM_PLUGIN_SOURCE to track a fork, a branch, a local checkout
+# (-e /path), or a git ref ("git+https://github.com/timgordontg/engrim@<ref>").
+SRC="${ENGRIM_PLUGIN_SOURCE:-engrim==0.7.1}"
 # Split into argv so a multi-token override like "-e /path" reaches pip as two args, not one
 # (a single quoted "$SRC" would collapse them and fail). The default git URL is one token.
 read -r -a SRC_ARGS <<< "$SRC"

--- a/plugin/scripts/engrim-bootstrap.sh
+++ b/plugin/scripts/engrim-bootstrap.sh
@@ -31,7 +31,7 @@ BIN="$(find_in_venv engrim)" || BIN=""
 # Pin the install source — the published PyPI wheel (fast, no git clone/build).
 # Override with ENGRIM_PLUGIN_SOURCE to track a fork, a branch, a local checkout
 # (-e /path), or a git ref ("git+https://github.com/timgordontg/engrim@<ref>").
-SRC="${ENGRIM_PLUGIN_SOURCE:-engrim==1.2.2}"
+SRC="${ENGRIM_PLUGIN_SOURCE:-engrim==1.3.0}"
 # Split into argv so a multi-token override like "-e /path" reaches pip as two args, not one
 # (a single quoted "$SRC" would collapse them and fail). The default git URL is one token.
 read -r -a SRC_ARGS <<< "$SRC"

--- a/plugin/scripts/engrim-bootstrap.sh
+++ b/plugin/scripts/engrim-bootstrap.sh
@@ -31,7 +31,7 @@ BIN="$(find_in_venv engrim)" || BIN=""
 # Pin the install source — the published PyPI wheel (fast, no git clone/build).
 # Override with ENGRIM_PLUGIN_SOURCE to track a fork, a branch, a local checkout
 # (-e /path), or a git ref ("git+https://github.com/timgordontg/engrim@<ref>").
-SRC="${ENGRIM_PLUGIN_SOURCE:-engrim==1.2.1}"
+SRC="${ENGRIM_PLUGIN_SOURCE:-engrim==1.2.2}"
 # Split into argv so a multi-token override like "-e /path" reaches pip as two args, not one
 # (a single quoted "$SRC" would collapse them and fail). The default git URL is one token.
 read -r -a SRC_ARGS <<< "$SRC"

--- a/plugin/scripts/engrim-bootstrap.sh
+++ b/plugin/scripts/engrim-bootstrap.sh
@@ -13,19 +13,31 @@ set -euo pipefail
 
 DATA="${CLAUDE_PLUGIN_DATA:?CLAUDE_PLUGIN_DATA is required}"
 VENV="$DATA/venv"
-BIN="$VENV/bin/engrim"
 STAMP="$DATA/.installed-source"
+
+# A venv puts its entry points in bin/ on POSIX and in Scripts/ (as .exe) on Windows. Only bin/ was
+# ever checked, so under Git Bash the install would succeed and then fail its own `-x` test: the
+# plugin reported "install failed" every session and all four hooks no-opped forever.
+find_in_venv() {                      # $1 = base name, e.g. engrim / python
+  local c
+  for c in "$VENV/bin/$1" "$VENV/Scripts/$1.exe" "$VENV/Scripts/$1"; do
+    if [ -x "$c" ]; then printf '%s' "$c"; return 0; fi
+  done
+  return 1
+}
+
+BIN="$(find_in_venv engrim)" || BIN=""
 
 # Pin the install source — the published PyPI wheel (fast, no git clone/build).
 # Override with ENGRIM_PLUGIN_SOURCE to track a fork, a branch, a local checkout
 # (-e /path), or a git ref ("git+https://github.com/timgordontg/engrim@<ref>").
-SRC="${ENGRIM_PLUGIN_SOURCE:-engrim==1.1.0}"
+SRC="${ENGRIM_PLUGIN_SOURCE:-engrim==1.2.1}"
 # Split into argv so a multi-token override like "-e /path" reaches pip as two args, not one
 # (a single quoted "$SRC" would collapse them and fail). The default git URL is one token.
 read -r -a SRC_ARGS <<< "$SRC"
 
 # Fast path: already installed at the desired source -> nothing to do.
-if [ -x "$BIN" ] && [ -f "$STAMP" ] && [ "$(cat "$STAMP")" = "$SRC" ]; then
+if [ -n "$BIN" ] && [ -f "$STAMP" ] && [ "$(cat "$STAMP")" = "$SRC" ]; then
   exit 0
 fi
 
@@ -36,22 +48,30 @@ installed=""
 
 # Preferred path: uv handles venv creation + pip in one fast, self-contained tool.
 if command -v uv >/dev/null 2>&1; then
-  if uv venv "$VENV" >/dev/null 2>&1 \
-     && uv pip install --quiet --python "$VENV/bin/python" "${SRC_ARGS[@]}" >/dev/null 2>&1; then
-    installed=1
+  if uv venv "$VENV" >/dev/null 2>&1; then
+    VPY="$(find_in_venv python)" || VPY=""
+    if [ -n "$VPY" ] \
+       && uv pip install --quiet --python "$VPY" "${SRC_ARGS[@]}" >/dev/null 2>&1; then
+      installed=1
+    fi
   fi
 fi
 
 # Fallback: stdlib venv. On Debian/Ubuntu a venv can come up *without* pip
 # (the python3-venv / ensurepip split), so repair pip via ensurepip first.
 if [ -z "$installed" ]; then
-  PY="$(command -v python3 || true)"
+  # `python3` is the POSIX spelling; the Windows installer ships `python` (and a `py` launcher).
+  PY="$(command -v python3 || command -v python || true)"
   if [ -z "$PY" ]; then
     echo "engrim plugin: no uv and no python3 on PATH — skipping; hooks will no-op." >&2
     exit 0
   fi
   "$PY" -m venv "$VENV" >/dev/null 2>&1 || "$PY" -m venv --without-pip "$VENV" >/dev/null 2>&1 || true
-  VPY="$VENV/bin/python"
+  VPY="$(find_in_venv python)" || VPY=""
+  if [ -z "$VPY" ]; then
+    echo "engrim plugin: could not create a venv — skipping; hooks will no-op." >&2
+    exit 0
+  fi
   if ! "$VPY" -m pip --version >/dev/null 2>&1; then
     "$VPY" -m ensurepip --upgrade >/dev/null 2>&1 || true
   fi
@@ -61,7 +81,8 @@ if [ -z "$installed" ]; then
   fi
 fi
 
-if [ -n "$installed" ] && [ -x "$BIN" ]; then
+BIN="$(find_in_venv engrim)" || BIN=""     # re-resolve: it only exists now that pip has run
+if [ -n "$installed" ] && [ -n "$BIN" ]; then
   printf '%s' "$SRC" >"$STAMP"
   # Warm the static embedder once so the first prompt isn't slowed by a cold load.
   "$BIN" stats >/dev/null 2>&1 || true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "engrim"
-version = "0.7.2"
+version = "0.8.0"
 description = "Project-scoped, cross-session memory for AI coding agents — hybrid keyword+semantic retrieval over a tagged SQLite store."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "engrim"
-version = "0.8.0"
+dynamic = ["version"]
 description = "Project-scoped, cross-session memory for AI coding agents — hybrid keyword+semantic retrieval over a tagged SQLite store."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -27,6 +27,9 @@ Homepage = "https://github.com/timgordontg/engrim"
 
 [project.scripts]
 engrim = "engrim.cli:main"
+
+[tool.setuptools.dynamic]
+version = { attr = "engrim.__version__" }   # single source of truth: src/engrim/__init__.py
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "engrim"
-version = "0.6.4"
+version = "0.7.0"
 description = "Project-scoped, cross-session memory for AI coding agents — hybrid keyword+semantic retrieval over a tagged SQLite store."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "engrim"
-version = "0.7.1"
+version = "0.7.2"
 description = "Project-scoped, cross-session memory for AI coding agents — hybrid keyword+semantic retrieval over a tagged SQLite store."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "engrim"
-version = "0.7.0"
+version = "0.7.1"
 description = "Project-scoped, cross-session memory for AI coding agents — hybrid keyword+semantic retrieval over a tagged SQLite store."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,12 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "engrim"
 dynamic = ["version"]
-description = "Project-scoped, cross-session memory for AI coding agents — hybrid keyword+semantic retrieval over a tagged SQLite store."
+description = "Project-scoped, cross-session episodic memory for AI coding agents (Google Antigravity, Claude Code, Cursor MCP) — local SQLite hybrid keyword+semantic store."
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }
 authors = [{ name = "Tim Gordon" }]
-keywords = ["ai", "agents", "memory", "context", "retrieval", "sqlite", "claude-code", "llm", "rag"]
+keywords = ["ai", "agents", "memory", "antigravity", "claude-code", "cursor", "gemini", "deepmind", "mcp", "context-continuity"]
 classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",

--- a/src/engrim/__init__.py
+++ b/src/engrim/__init__.py
@@ -1,3 +1,3 @@
 """engrim — project-scoped, cross-session memory for AI coding agents."""
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"

--- a/src/engrim/__init__.py
+++ b/src/engrim/__init__.py
@@ -1,3 +1,3 @@
 """engrim — project-scoped, cross-session memory for AI coding agents."""
 
-__version__ = "0.6.4"
+__version__ = "0.7.0"

--- a/src/engrim/__init__.py
+++ b/src/engrim/__init__.py
@@ -1,3 +1,3 @@
 """engrim — project-scoped, cross-session memory for AI coding agents."""
 
-__version__ = "0.8.1"
+__version__ = "1.0.0"

--- a/src/engrim/__init__.py
+++ b/src/engrim/__init__.py
@@ -1,3 +1,3 @@
 """engrim — project-scoped, cross-session memory for AI coding agents."""
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"

--- a/src/engrim/__init__.py
+++ b/src/engrim/__init__.py
@@ -1,3 +1,3 @@
 """engrim — project-scoped, cross-session memory for AI coding agents."""
 
-__version__ = "0.7.2"
+__version__ = "0.8.1"

--- a/src/engrim/__init__.py
+++ b/src/engrim/__init__.py
@@ -1,3 +1,3 @@
 """engrim — project-scoped, cross-session memory for AI coding agents."""
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"

--- a/src/engrim/__init__.py
+++ b/src/engrim/__init__.py
@@ -1,3 +1,3 @@
 """engrim — project-scoped, cross-session memory for AI coding agents."""
 
-__version__ = "1.2.2"
+__version__ = "1.3.0"

--- a/src/engrim/__init__.py
+++ b/src/engrim/__init__.py
@@ -1,3 +1,3 @@
 """engrim — project-scoped, cross-session memory for AI coding agents."""
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"

--- a/src/engrim/__init__.py
+++ b/src/engrim/__init__.py
@@ -1,3 +1,3 @@
 """engrim — project-scoped, cross-session memory for AI coding agents."""
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"

--- a/src/engrim/__init__.py
+++ b/src/engrim/__init__.py
@@ -1,3 +1,3 @@
 """engrim — project-scoped, cross-session memory for AI coding agents."""
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"

--- a/src/engrim/__init__.py
+++ b/src/engrim/__init__.py
@@ -1,3 +1,3 @@
 """engrim — project-scoped, cross-session memory for AI coding agents."""
 
-__version__ = "1.1.2"
+__version__ = "1.2.0"

--- a/src/engrim/__init__.py
+++ b/src/engrim/__init__.py
@@ -1,3 +1,3 @@
 """engrim — project-scoped, cross-session memory for AI coding agents."""
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"

--- a/src/engrim/adapters/__init__.py
+++ b/src/engrim/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Adapters for cross-agent memory lifecycle integration."""

--- a/src/engrim/adapters/agy.py
+++ b/src/engrim/adapters/agy.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Antigravity (AGY) Lifecycle Hook Adapter for engrim.
+
+Bridges Antigravity lifecycle hooks (PreInvocation, Stop) to the engrim memory engine.
+
+Usage in ~/.gemini/config/hooks.json:
+  PreInvocation: engrim hook --agent agy --event boot
+  Stop:          engrim hook --agent agy --event stop
+"""
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import subprocess
+import sys
+
+from engrim.cli import (
+    connect,
+    cmd_context,
+    build_parser,
+    DEFAULT_DB,
+    _ingest_transcript,
+    _uncaptured_count,
+)
+
+
+def get_project_path(payload: dict | None = None) -> str:
+    """Extract project root directory from hook payload or cwd."""
+    if not payload:
+        return os.getcwd()
+    ws_paths = payload.get("workspacePaths") or []
+    if ws_paths:
+        return ws_paths[0]
+    return payload.get("cwd") or os.getcwd()
+
+
+def _read_stdin_payload() -> dict:
+    if not sys.stdin.isatty():
+        try:
+            return json.load(sys.stdin)
+        except Exception:
+            return {}
+    return {}
+
+
+def handle_boot(
+    payload: dict | None = None,
+    *,
+    db_path: str | None = None,
+    print_output: bool = True,
+) -> dict:
+    """Handle Antigravity PreInvocation boot hook.
+
+    Extracts project workspace, fetches engrim context, and formats output as injectSteps.
+    """
+    if payload is None:
+        payload = _read_stdin_payload()
+
+    project = get_project_path(payload)
+
+    # Auto-checkpoint baseline in background if checkpoint utility is available
+    try:
+        subprocess.Popen(
+            ["checkpoint", "save", "--auto", "-p", project, "-l", "Auto Session Boot Checkpoint"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except Exception:
+        pass
+
+    db = db_path or os.environ.get("ENGRIM_DB", DEFAULT_DB)
+    try:
+        conn = connect(db)
+        parser = build_parser()
+        args = parser.parse_args(["context", "-p", project])
+        args.agent_directive = True
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            cmd_context(conn, args)
+        conn.close()
+        context_text = buf.getvalue().strip()
+    except Exception as e:
+        context_text = f"engrim context error: {e}"
+
+    out = {
+        "injectSteps": [
+            {
+                "ephemeralMessage": context_text
+            }
+        ]
+    }
+    if print_output:
+        print(json.dumps(out))
+    return out
+
+
+def handle_stop(
+    payload: dict | None = None,
+    *,
+    db_path: str | None = None,
+    print_output: bool = True,
+) -> dict:
+    """Handle Antigravity Stop lifecycle hook.
+
+    Ingests session transcript and verifies recent decisions are captured.
+    """
+    if payload is None:
+        payload = _read_stdin_payload()
+
+    project = get_project_path(payload)
+    transcript_path = payload.get("transcriptPath") or payload.get("transcript_path")
+    session_id = payload.get("conversationId") or payload.get("session_id")
+
+    db = db_path or os.environ.get("ENGRIM_DB", DEFAULT_DB)
+    if transcript_path and os.path.exists(transcript_path):
+        try:
+            conn = connect(db)
+            _ingest_transcript(conn, project, transcript_path, session=session_id)
+            # Verify recent decisions are captured
+            unc = _uncaptured_count(conn, project)
+            if unc > 0:
+                sys.stderr.write(f"[engrim] {unc} recent decision(s) not yet curated in {project}\n")
+            conn.close()
+        except Exception as e:
+            sys.stderr.write(f"[engrim] stop hook error: {e}\n")
+
+    out: dict = {}
+    if print_output:
+        print(json.dumps(out))
+    return out
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        sys.exit("Usage: python -m engrim.adapters.agy [boot|stop]")
+    mode = sys.argv[1].lower()
+    if mode == "boot":
+        handle_boot()
+    elif mode == "stop":
+        handle_stop()
+    else:
+        sys.exit(f"Unknown mode: {mode}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/engrim/cli.py
+++ b/src/engrim/cli.py
@@ -564,15 +564,30 @@ def cmd_assist(conn, a) -> None:
             break
         out.append(line)
         used += len(line) + 1
-    if not out:
-        return emit("")                                       # nothing relevant -> spend nothing
-    try:    # record the pull so the ambient status line can show "N in play" — out-of-band, never in chat
-        _meta_set(conn, project, "minder_n", str(len(out)))
-        _meta_set(conn, project, "minder_ts", _now())
+    # Mid-session auto-curate backstop: if a real backlog of uncaptured decisions has built up inside a
+    # long session, nudge the AGENT — not the user — to promote the durable ones now (the boot directive
+    # only fires at the NEXT session). Conservative: gated on a backlog floor so ordinary work doesn't
+    # trip it; decision-only + dedup-safe, so it self-clears the moment they're captured. Cheap, model-free.
+    directive = ""
+    try:
+        unc = _uncaptured_count(conn, project)
+        if unc >= _ASSIST_CURATE_FLOOR:
+            directive = (f"\n[engrim · auto-curate] {unc} decisions are logged but not yet in curated "
+                         "memory. Before your next reply, SILENTLY `engrim add` the durable ones "
+                         "(skip chatter, reversed calls, and false-positives); don't announce it.")
     except Exception:
-        pass
-    emit("Possibly-relevant project memory (engrim), pulled for this message — use if helpful:\n"
-         + "\n".join(out))
+        directive = ""
+    if not out and not directive:
+        return emit("")                                       # nothing relevant -> spend nothing
+    if out:
+        try:  # record the pull so the ambient status line can show "N in play" — out-of-band, never in chat
+            _meta_set(conn, project, "minder_n", str(len(out)))
+            _meta_set(conn, project, "minder_ts", _now())
+        except Exception:
+            pass
+    head = ("Possibly-relevant project memory (engrim), pulled for this message — use if helpful:\n"
+            + "\n".join(out)) if out else ""
+    emit((head + directive).strip())
 
 
 def cmd_statusline(conn, a) -> None:
@@ -711,6 +726,11 @@ _TAIL_SNIPPET_CAP = 180    # per-line truncation
 # model-free on every status refresh; before anything is curated, callers fall back to their count
 # window so a fresh project stays lean.
 _UNCAPTURED_MAX_SCAN = 200
+
+# Mid-session auto-curate backstop: the boot directive only fires at the NEXT session, so a single long
+# session can accumulate uncaptured decisions. Once the backlog crosses this floor the minder nudges the
+# AGENT (not the user) to promote them. Set high enough that ordinary work-in-progress never trips it.
+_ASSIST_CURATE_FLOOR = 4
 
 
 def _parse_ts(s):
@@ -863,9 +883,28 @@ def cmd_context(conn, a) -> None:
     # Clear-readiness verdict — the same gentle signal as the status bar, so the summary answers
     # "safe to /clear?" too. Capturing is a normal part of working, so this is an invitation (✎),
     # never a warning. Only shown once there's session history to reason about.
+    #
+    # At BOOT (agent_directive, set by `engrim hook`) this flips from a passive nudge-to-the-human into
+    # an active directive-to-the-AGENT: a window-close / session-limit expiry can't curate itself (no
+    # hook fires reliably at a hard kill), so the *next* session's agent is the recovery path. The raw
+    # log already survived the close (Stop hook every turn + boot transcript reconciliation, #101); this
+    # directive tells the fresh agent to promote the durable survivors into curated memory before it does
+    # anything else — zero user interaction, judgment applied (so #219-type false-positives are skipped),
+    # dedup-safe (the detector drops anything already curated). Self-healing: the capture-floor keeps a
+    # survivor eligible across boots until it is actually captured.
     if conn.execute("SELECT 1 FROM log WHERE project = ? LIMIT 1", (project,)).fetchone():
         unc = _uncaptured_count(conn, project)
-        if unc:
+        if getattr(a, "agent_directive", False):
+            if unc:   # cheap decision-only gate; the agent's `engrim review` does the thorough semantic pass
+                print("\n[⟳ AUTO-CURATE — a prior session left decisions in the raw log but NOT in curated "
+                      "memory (a window-close/limit-expiry can't curate itself). You are the recovery path.]")
+                print("Before you address the user's message, SILENTLY curate the durable survivors:")
+                print("  1. `engrim review`  → the full uncaptured-decision list (heuristic candidates)")
+                print("  2. for each GENUINELY durable one:  "
+                      "engrim add -t <decision|fact|state|feedback> -s \"<one line>\" [-d \"<why>\"]")
+                print("  Skip chatter, reversed calls, and product copy (known false-positives) — keep the "
+                      "store high-signal. Don't announce this; just curate, then proceed.")
+        elif unc:
             print(f"\n✎ {unc} recent decision(s) not yet curated — worth capturing before your next "
                   "/clear:  engrim add -t decision -s \"…\"")
         else:
@@ -898,6 +937,7 @@ def cmd_hook(conn, a) -> None:
         except Exception:
             pass
     a.json = False
+    a.agent_directive = True   # boot path: emit the auto-curate directive (recovery for a hard window-close)
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
         cmd_context(conn, a)

--- a/src/engrim/cli.py
+++ b/src/engrim/cli.py
@@ -42,14 +42,25 @@ def _now() -> str:
     return _dt.datetime.now().astimezone().isoformat(timespec="seconds")
 
 
-_PROJECT_MARKERS = (".git", ".hg", ".svn")
+# A project root is a dir holding a VCS dir OR a `.claude` project dir. `.claude` matters because
+# not every project is a git repo (e.g. a data/ops workspace) — without a marker the tag would fall
+# back to the raw cwd, so launching from a subdir silently files records under a SIBLING scope the
+# status line and boot pack never read (records land, counter never moves: "is it even logging?").
+_PROJECT_MARKERS = (".git", ".hg", ".svn", ".claude")
 
 
 def _git_root(start: str):
-    """Walk up from `start` to the nearest repo root (.git/.hg/.svn). None if not in a repo."""
+    """Walk up from `start` to the nearest project root (a dir with a _PROJECT_MARKER). None if none.
+
+    $HOME is NEVER treated as a project root: `~/.claude` (and a stray `~/.git`) exist for almost
+    everyone, so anchoring there would collapse every non-repo project under home into ONE bucket —
+    worse than the no-marker fallback. We skip the marker check AT home but keep walking past it, so a
+    real repo above home (unusual) still resolves while `~/.claude` can't become a catch-all anchor."""
+    home = os.path.realpath(os.path.expanduser("~"))
     cur = os.path.abspath(start)
     while True:
-        if any(os.path.exists(os.path.join(cur, m)) for m in _PROJECT_MARKERS):
+        if os.path.realpath(cur) != home and \
+                any(os.path.exists(os.path.join(cur, m)) for m in _PROJECT_MARKERS):
             return cur
         parent = os.path.dirname(cur)
         if parent == cur:
@@ -61,7 +72,8 @@ def _resolve_project(p, cwd=None):
     """Project tag precedence: explicit -p  >  $ENGRIM_PROJECT  >  git root of cwd  >  cwd.
 
     $ENGRIM_PROJECT gives a stable tag across machines/containers (host path != container path);
-    git-root makes the tag the same no matter which subdirectory you launch from. `cwd` overrides the
+    project-root (a .git/.hg/.svn repo OR a .claude dir) makes the tag the same no matter which
+    subdirectory you launch from — non-repo workspaces anchor on .claude. `cwd` overrides the
     base directory (default: the process's): a hook should resolve against the workspace Claude Code
     reports, not whatever cwd the hook process happens to inherit — see cmd_log's --hook path.
     """

--- a/src/engrim/cli.py
+++ b/src/engrim/cli.py
@@ -213,6 +213,32 @@ def _meta_set(conn, project, key, value):
     conn.commit()
 
 
+def add_memory(conn, *, project, type, summary, detail=None, status="active",
+               tags=None, links=None, source=None) -> int:
+    """Insert one memory record and best-effort auto-embed it; return the new id.
+
+    The shared write core behind both the `add` CLI command and the MCP server, so a
+    record created either way is identical and immediately searchable by meaning.
+    `tags`/`links` are lists (already normalized by the caller)."""
+    cur = conn.execute(
+        "INSERT INTO memories(ts,project,type,summary,detail,status,tags,links,source) "
+        "VALUES(?,?,?,?,?,?,?,?,?)",
+        (_now(), project, type, summary, detail, status,
+         json.dumps(tags or []), json.dumps(links or []), source),
+    )
+    conn.commit()
+    # Auto-embed so the record is searchable by meaning immediately — no manual `engrim embed` step.
+    # Best-effort: a missing/slow/broken backend must never fail or slow down a write.
+    fn, name = _resolve_embedder()
+    if fn:
+        try:
+            _embed_row(conn, cur.lastrowid, summary, detail, fn, name)
+            conn.commit()
+        except Exception:
+            pass
+    return cur.lastrowid
+
+
 def cmd_add(conn, a) -> None:
     if a.type not in TYPES:
         sys.exit(f"--type must be one of {TYPES}")
@@ -220,24 +246,11 @@ def cmd_add(conn, a) -> None:
         sys.exit("--summary cannot be empty")
     # --global writes to the user-layer that loads in every project; otherwise scope to the cwd's project.
     project = GLOBAL_PROJECT if getattr(a, "globl", False) else _resolve_project(a.project)
-    cur = conn.execute(
-        "INSERT INTO memories(ts,project,type,summary,detail,status,tags,links,source) "
-        "VALUES(?,?,?,?,?,?,?,?,?)",
-        (_now(), project, a.type, a.summary, a.detail, a.status,
-         json.dumps(_csv(a.tags)), json.dumps(_csv(a.links)), a.source),
-    )
-    conn.commit()
+    new_id = add_memory(conn, project=project, type=a.type, summary=a.summary,
+                        detail=a.detail, status=a.status,
+                        tags=_csv(a.tags), links=_csv(a.links), source=a.source)
     shown = "global · loads in every project" if project == GLOBAL_PROJECT else project
-    print(f"+ #{cur.lastrowid} [{a.type}] {shown}\n  {a.summary}")
-    # Auto-embed so the record is searchable by meaning immediately — no manual `engrim embed` step.
-    # Best-effort: a missing/slow/broken backend must never fail or slow down a write.
-    fn, name = _resolve_embedder()
-    if fn:
-        try:
-            _embed_row(conn, cur.lastrowid, a.summary, a.detail, fn, name)
-            conn.commit()
-        except Exception:
-            pass
+    print(f"+ #{new_id} [{a.type}] {shown}\n  {a.summary}")
 
 
 def _row_line(r, detail: bool) -> str:
@@ -1690,7 +1703,16 @@ def build_parser() -> argparse.ArgumentParser:
     pst.add_argument("-p", "--project", default="auto")
     pst.add_argument("-b", "--budget", type=int, default=4000)
     pst.set_defaults(func=cmd_stats)
+
+    pmcp = sub.add_parser("mcp", help="run engrim as an MCP server (stdio) for clients like Claude Code")
+    pmcp.set_defaults(func=cmd_mcp)
     return p
+
+
+def cmd_mcp(conn, a) -> None:
+    """Run engrim as an MCP server over stdio (for MCP clients like Claude Code)."""
+    from engrim.mcp_server import serve
+    serve(conn)
 
 
 def main(argv=None) -> None:

--- a/src/engrim/cli.py
+++ b/src/engrim/cli.py
@@ -421,11 +421,13 @@ def _cosine(a, b):
 
 
 # Minimum cosine for a semantic match to count. Below this the static embedder is at noise level
-# (empirically with potion-8M: genuine matches land ~0.50-0.73, unrelated text ~0.00-0.12, with a
-# wide empty gap between). Without a floor, a zero-overlap query returns whatever scores 0.001 above
-# the rest — a confidently-wrong hit. Recall and the minder use this; the stricter capture-check in
-# `review` (_CAPTURED_SIM) is separate, because a false "safe to clear" costs more than a missed hit.
-_SEM_FLOOR = 0.35
+# (empirically with potion-8M: unrelated text ~0.00-0.12; strong matches ~0.50-0.73; short natural-
+# language paraphrases of a record — e.g. "what database did we pick" against a SQLite decision —
+# land ~0.30-0.46). The floor sits at 0.30 to admit those genuine paraphrases while staying well clear
+# of the <0.12 noise band. Lowering it only ever adds matches above 0.30; nothing that cleared the old
+# value drops out. Recall and the minder use this; the stricter capture-check in `review`
+# (_CAPTURED_SIM) is separate, because a false "safe to clear" costs more than a missed hit.
+_SEM_FLOOR = 0.30
 
 
 def _semantic_rows(conn, project, query, k):

--- a/src/engrim/cli.py
+++ b/src/engrim/cli.py
@@ -620,20 +620,46 @@ def cmd_statusline(conn, a) -> None:
 
 _BOOT_SUMMARY_CAP = 200   # keep the pack lean: essay-length summaries are truncated in the boot pack
 
+# The designated session-resume cursor: the newest active record carrying this tag is pinned to the
+# TOP of the boot pack and shown UNTRUNCATED, so a fresh session after /clear opens on exactly where
+# we left off — continue-as-clear (#191 continuity, taken the last mile). It rides OUTSIDE the per-type
+# round-robin and isn't summary-capped; everything else fills the budget around it.
+_RESUME_TAG = "resume-pointer"
+
+
+def _is_resume(row):
+    """True if a record is the session-resume cursor (tagged _RESUME_TAG). Tolerant of malformed tags."""
+    try:
+        return _RESUME_TAG in json.loads(row["tags"] or "[]")
+    except Exception:
+        return False
+
 
 def _boot_pack(rows, budget):
     """Build the session-boot slice under a char budget, FAIRLY across types so a flood of one type
     (e.g. dozens of feedback records) can't starve recent decisions/facts. Returns [(row, summary)]
-    with long summaries truncated, plus the total char cost. Shared by `context` (display) and `stats`
-    (economics) so the reported cost is exactly the pack that loads."""
+    with long summaries truncated, plus the total char cost. The resume cursor (if any) is pinned
+    first and untruncated. Shared by `context` (display) and `stats` (economics) so the reported cost
+    is exactly the pack that loads."""
+    picked, used = [], 0
+    # Pin the resume cursor first, untruncated — the one record we never clip, since it IS the place to
+    # resume. Newest wins if several are tagged. It still counts against the budget; the rest fills around.
+    resume = [r for r in rows if _is_resume(r)]
+    cursor = max(resume, key=lambda r: r["ts"]) if resume else None
+    if cursor is not None:
+        csum = cursor["summary"] or ""
+        picked.append((cursor, csum))
+        used += len(csum) + 40
     by_type = {}
     for r in rows:
+        if cursor is not None and r["id"] == cursor["id"]:
+            continue                                           # already pinned; don't round-robin it again
         by_type.setdefault(r["type"], []).append(r)
     for t in by_type:
         by_type[t].sort(key=lambda r: r["ts"], reverse=True)   # recent-first within a type
     order = sorted(by_type, key=lambda t: _PRIO.get(t, 9))      # priority order across types
     idx = {t: 0 for t in order}
-    picked, used, progressed = [], 0, True
+    progressed = True
     while progressed:
         progressed = False
         for t in order:                                        # round-robin: one per type per round
@@ -721,14 +747,15 @@ def _recent_tail(conn, project, scan=_TAIL_SCAN, max_items=_TAIL_MAX_ITEMS, budg
     rows = conn.execute(
         "SELECT ts, content FROM log WHERE project = ? ORDER BY ts DESC LIMIT ?",
         (project, _UNCAPTURED_MAX_SCAN)).fetchall()
+    tail_cues = _DECISION_CUES + _OPENTASK_CUES   # continuity: surface open loops, not just decisions
     seen, out, used = set(), [], 0
     for i, r in enumerate(rows):
         if _past_floor(r, floor, i, scan):       # reached the last capture point / lean window
             break
         content = r["content"] or ""
-        if not any(cue in content.lower() for cue in _DECISION_CUES):
+        if not any(cue in content.lower() for cue in tail_cues):
             continue
-        snip = _decision_snippet(content)
+        snip = _decision_snippet(content, tail_cues)
         key = snip.lower()[:80]
         if not snip or key in seen or _looks_like_narration(snip):
             continue
@@ -794,15 +821,25 @@ def cmd_context(conn, a) -> None:
     if picked:
         print(f"🧠 engrim · memory restored for this project — you don't have to re-explain · {project}")
         print(f"  {len(picked)} of {len(rows)} curated records loaded (~{used} chars) · the rest one `recall` away")
-        picked.sort(key=lambda rs: _PRIO.get(rs[0]["type"], 9))     # group by type for display (recent-first kept)
-        cur = None
-        for r, summ in picked:
-            if r["type"] != cur:
-                cur = r["type"]
-                print(f"\n[{cur.upper()}]")
+
+        def _line(r, summ):
             tags = ", ".join(json.loads(r["tags"] or "[]"))
             gtag = "  · global" if r["project"] == GLOBAL_PROJECT else ""   # rides along in every project
             print(f"- #{r['id']} {summ}" + (f"  ({tags})" if tags else "") + gtag)
+
+        # The resume cursor leads, in its own section, so a fresh session reads "where we left off" first.
+        cursor = next(((r, s) for r, s in picked if _is_resume(r)), None)
+        rest = [(r, s) for r, s in picked if not _is_resume(r)]
+        if cursor is not None:
+            print("\n[▶ RESUME HERE]")
+            _line(*cursor)
+        rest.sort(key=lambda rs: _PRIO.get(rs[0]["type"], 9))      # group by type for display (recent-first kept)
+        cur = None
+        for r, summ in rest:
+            if r["type"] != cur:
+                cur = r["type"]
+                print(f"\n[{cur.upper()}]")
+            _line(r, summ)
         if len(picked) < len(rows):
             print(f"\n(+{len(rows) - len(picked)} more · `engrim recall -q ...` to pull on demand)")
     # Recency tail: what was just decided but isn't a curated record yet — so a cold boot doesn't lose
@@ -1464,6 +1501,20 @@ _DECISION_CUES = (
     "we are using", "let's do", "lets do", "agreed on", "final call",
 )
 
+# Open-loop / next-action cues — distinct from decisions. The recency TAIL honors these too, so a
+# mid-task /clear still surfaces where we left off ("pick this up later", "the next step is …",
+# "still need to …"). The 'safe to clear?' nudge (_uncaptured_count) deliberately does NOT use them:
+# it counts real decisions, not every open loop, or it would nag on ordinary work-in-progress. Phrase-
+# based (not bare "next"/"resume") to avoid false hits; agent process-chatter is still dropped by the
+# narration filter, which catches "next i'll", "then i'll", etc.
+_OPENTASK_CUES = (
+    "next step", "next action", "next we", "next up", "the next thing",
+    "pick up later", "pick this up", "pick it back up", "pick back up", "pick this back up",
+    "where we left off", "left off", "still need to", "to do next", "todo", "to-do",
+    "blocked on", "blocking on", "open loop", "remaining work", "we'll continue",
+    "continue from here", "resume here", "resume pointer", "we'll pick", "pick up where",
+)
+
 # The agent's OWN process/meta narration trips the cue list ("let me close the loop by
 # capturing…", "next I'll switch to the tests") — these are workflow chatter, not project
 # decisions, and they inflate the "to capture" nudge (#197). A snippet dominated by a marker
@@ -1507,11 +1558,12 @@ _DECISION_SEM_FLOOR = 0.45
 _CAPTURED_SIM = 0.45
 
 
-def _decision_snippet(text):
-    """Tighten a turn down to the sentence that carried the decision cue."""
+def _decision_snippet(text, cues=_DECISION_CUES):
+    """Tighten a turn down to the sentence that carried the cue (decisions by default; the recency
+    tail passes the wider decision+open-task set so it can quote the open loop it matched)."""
     flat = (text or "").replace("\n", " ")
     for s in re.split(r"(?<=[.!?])\s+", flat):
-        if any(cue in s.lower() for cue in _DECISION_CUES):
+        if any(cue in s.lower() for cue in cues):
             return s.strip()
     return flat.strip()
 

--- a/src/engrim/cli.py
+++ b/src/engrim/cli.py
@@ -57,18 +57,43 @@ def _git_root(start: str):
         cur = parent
 
 
-def _resolve_project(p):
+def _resolve_project(p, cwd=None):
     """Project tag precedence: explicit -p  >  $ENGRIM_PROJECT  >  git root of cwd  >  cwd.
 
     $ENGRIM_PROJECT gives a stable tag across machines/containers (host path != container path);
-    git-root makes the tag the same no matter which subdirectory you launch from.
+    git-root makes the tag the same no matter which subdirectory you launch from. `cwd` overrides the
+    base directory (default: the process's): a hook should resolve against the workspace Claude Code
+    reports, not whatever cwd the hook process happens to inherit — see cmd_log's --hook path.
     """
     if p and p != "auto":
         return p
     env = os.environ.get("ENGRIM_PROJECT") or os.environ.get("CLAUDE_PROJECT_TAG")
     if env:
         return env
-    return _git_root(os.getcwd()) or os.getcwd()
+    base = cwd or os.getcwd()
+    return _git_root(base) or base
+
+
+def _payload_project(payload, explicit=None):
+    """Resolve the project for a hook / status line from its stdin payload, preferring the MOST STABLE
+    directory Claude Code offers so a session stays pinned to ONE project even if its cwd drifts during
+    the session (e.g. a tool subprocess chdir'd elsewhere):
+
+        -p  >  $ENGRIM_PROJECT  >  workspace.project_dir (the launch root — stable)  >
+        workspace.current_dir  >  cwd  >  the hook process's own cwd
+
+    project_dir is the directory Claude Code was started in and does not move; current_dir/cwd can.
+    Anchoring to it keeps the log's bucket, its byte cursor, and the status line's count all in
+    agreement for the whole session. Every entry point (status line, Stop hook, minder) routes through
+    here so they can never disagree on which project this session is."""
+    if explicit and explicit != "auto":
+        return explicit
+    env = os.environ.get("ENGRIM_PROJECT") or os.environ.get("CLAUDE_PROJECT_TAG")
+    if env:
+        return env
+    ws = (payload or {}).get("workspace") or {}
+    base = ws.get("project_dir") or ws.get("current_dir") or (payload or {}).get("cwd")
+    return _resolve_project(None, base)   # base may be None -> falls back to the process cwd; git-root applied
 
 
 def _csv(val):
@@ -501,14 +526,18 @@ def cmd_assist(conn, a) -> None:
     def emit(block):
         print(json.dumps({"hookSpecificOutput": {
             "hookEventName": "UserPromptSubmit", "additionalContext": block}}))
+    payload = {}
     try:
-        prompt = (json.load(sys.stdin) or {}).get("prompt") or ""
+        payload = json.load(sys.stdin) or {}
     except Exception:
         return emit("")
+    prompt = payload.get("prompt") or ""
     terms = _content_terms(prompt)
     if len(terms) < 2:               # too little signal to be worth any tokens
         return emit("")
-    project = _resolve_project(a.project)
+    # Same stable resolution as the status line + log hook, so the minder writes its "in play" marker
+    # under the project the bar actually reads — they never disagree about which project this session is.
+    project = _payload_project(payload, a.project)
     try:
         rows = _minder_rows(conn, project, " ".join(terms), prompt, a.k)
     except Exception:
@@ -541,19 +570,15 @@ def cmd_statusline(conn, a) -> None:
     or nagging a security-aware user. Reads Claude Code's session JSON on stdin (for the workspace dir),
     falls back to cwd. Fast + model-free: it only counts rows + reads meta, so it's safe to run on every
     status refresh."""
-    cwd = sess = None
+    data, sess = {}, None
     try:
         data = json.load(sys.stdin) or {}
-        cwd = (data.get("workspace") or {}).get("current_dir") or data.get("cwd")
         sess = data.get("session_id") or data.get("sessionId")
     except Exception:
         pass
-    if cwd:
-        try:
-            os.chdir(cwd)
-        except Exception:
-            pass
-    project = _resolve_project(a.project)
+    # Resolve from the session's STABLE launch dir (project_dir), not whatever cwd the status-line
+    # process inherited — a drifted cwd would point the bar at a different project's memory mid-session.
+    project = _payload_project(data, a.project)
     try:
         n = conn.execute("SELECT COUNT(*) FROM memories WHERE project=? AND status='active'",
                          (project,)).fetchone()[0]
@@ -1359,6 +1384,15 @@ def _ingest_transcript(conn, project, path, session=None, include_thinking=False
                  o.get("type"), text, line, o.get("uuid")))
             added += cur.rowcount
         end = f.tell()
+    # Advance the cursor monotonically. When start==0 we deliberately re-read from the top (new
+    # session, or a rotated/truncated file detected above), so the freshly-read position is correct.
+    # Otherwise never rewind past where a concurrent run may already have advanced: two overlapping
+    # Stop hooks must not let a slower one reopen ground the faster one already covered.
+    if start:
+        try:
+            end = max(end, int(_meta_get(conn, project, okey) or 0))
+        except (TypeError, ValueError):
+            pass
     _meta_set(conn, project, okey, str(end))   # commits
     conn.commit()
     return added
@@ -1367,15 +1401,24 @@ def _ingest_transcript(conn, project, path, session=None, include_thinking=False
 def cmd_log(conn, a) -> None:
     """Append to the raw transcript log. `--hook` reads a Stop-hook JSON from stdin and ingests the
     session's new turns; `--from-transcript PATH` ingests a file; otherwise append one -r/-c turn."""
-    project = _resolve_project(a.project)
     if a.hook:
         try:
             payload = json.load(sys.stdin)
         except Exception:
             return
-        n = _ingest_transcript(conn, project, payload.get("transcript_path"),
-                               payload.get("session_id"), a.include_thinking)
+        # Resolve from the session's STABLE launch dir, not the hook process's os.getcwd(). A Stop
+        # hook can be spawned with an incidental cwd (e.g. it inherits one a tool subprocess chdir'd
+        # into), and a single Claude session is one transcript file with one session id. Keying
+        # ingestion off an unstable cwd splits that session across project buckets — each with its own
+        # byte-offset cursor — so turns after the drift land in the wrong project, the original
+        # cursor stalls, and the status line's per-(project,session) count freezes. Routing through
+        # _payload_project (project_dir-first) keeps the whole session in one bucket and, because the
+        # status line resolves the same way, keeps the bucket and the displayed count in agreement.
+        project = _payload_project(payload, a.project)
+        _ingest_transcript(conn, project, payload.get("transcript_path"),
+                           payload.get("session_id"), a.include_thinking)
         return  # silent: this runs from a hook
+    project = _resolve_project(a.project)
     if a.from_transcript:
         n = _ingest_transcript(conn, project, a.from_transcript, a.session, a.include_thinking)
         print(f"logged {n} new turn(s) from transcript -> project={project}")

--- a/src/engrim/cli.py
+++ b/src/engrim/cli.py
@@ -380,6 +380,11 @@ def _resolve_embedder():
         _EMBEDDER = (None, None)
         return _EMBEDDER
     try:
+        # huggingface_hub's snapshot_download prints a "Fetching N files" tqdm bar to STDERR on
+        # first model fetch. Any caller capturing 2>&1 (the SessionStart hook, agent tooling) gets
+        # that noise injected into context. Disable HF progress bars before model2vec imports the
+        # hub. setdefault so an explicit override from the environment still wins.
+        os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
         from model2vec import StaticModel
         model_id = os.environ.get("ENGRIM_EMBED_MODEL", "minishlab/potion-base-8M")
         model = StaticModel.from_pretrained(model_id)

--- a/src/engrim/cli.py
+++ b/src/engrim/cli.py
@@ -640,15 +640,66 @@ _TAIL_MAX_ITEMS = 3        # hard cap on tail lines — recency hint, not a tran
 _TAIL_BUDGET = 600         # own char sub-budget, independent of the curated boot budget
 _TAIL_SNIPPET_CAP = 180    # per-line truncation
 
+# Capture-floor: how far back the AUTOMATIC recency net looks. A bare last-N-turns window silently
+# loses a decision when a long tail of verification/chatter — or a hard session kill mid-capture —
+# pushes it past N before the next boot. So rather than a fixed turn count, scan back to the
+# project's newest curated record: every decision-signal turn logged SINCE the last `add` stays
+# eligible to resurface until it is itself captured. A hard ceiling keeps the scan cheap and
+# model-free on every status refresh; before anything is curated, callers fall back to their count
+# window so a fresh project stays lean.
+_UNCAPTURED_MAX_SCAN = 200
+
+
+def _parse_ts(s):
+    """ISO-8601 timestamp -> aware datetime (None if unparseable). Log turns are stamped 'Z' (UTC)
+    while curated records carry a local offset; normalizing 'Z' lets the net compare a turn against
+    the last capture as instants, not mismatched strings."""
+    try:
+        d = _dt.datetime.fromisoformat((s or "").replace("Z", "+00:00"))
+    except Exception:
+        return None
+    return d if d.tzinfo else d.astimezone()   # a naive stamp -> assume local, so comparisons stay aware-safe
+
+
+def _capture_floor(conn, project):
+    """Instant of the project's newest curated record — the 'caught up to here' mark the recency net
+    scans back to. None if nothing is curated yet. Project-scoped: a global record isn't a capture of
+    THIS project's decisions."""
+    try:
+        row = conn.execute(
+            "SELECT MAX(ts) FROM memories WHERE project = ? AND status = 'active'", (project,)).fetchone()
+    except Exception:
+        return None
+    return _parse_ts(row[0]) if row and row[0] else None
+
+
+def _past_floor(r, floor, i, scan):
+    """Stop condition for a recency scan iterating log rows newest-first. Hybrid window: always scan
+    the lean recent `scan` turns, AND extend back to the capture floor — stop only once a turn is
+    BOTH outside the recent window and older than the last capture. The recent window protects a
+    just-made decision even when a later unrelated `add` moved the floor past it; the floor extends
+    reach for a decision buried under a long tail of chatter (or a mid-capture session kill)."""
+    if i < scan:
+        return False                       # always scan the lean recent window
+    if floor is None:
+        return True                        # past the window, nothing curated to extend reach
+    rts = _parse_ts(r["ts"])
+    # strict `<`: a turn in the floor's own second (record ts is second-precision) is still scanned,
+    # biasing toward surfacing; the captured-check dedups any that were genuinely captured.
+    return rts is None or rts < floor      # past window AND before the last capture -> stop
+
 
 def _recent_tail(conn, project, scan=_TAIL_SCAN, max_items=_TAIL_MAX_ITEMS, budget=_TAIL_BUDGET):
     """Recent uncaptured decision-signal turns from the log, newest-first, under a hard item + char cap.
     Reuses review's detector; dedups against curated memory lexically so the boot stays fast."""
+    floor = _capture_floor(conn, project)
     rows = conn.execute(
         "SELECT ts, content FROM log WHERE project = ? ORDER BY ts DESC LIMIT ?",
-        (project, scan)).fetchall()
+        (project, _UNCAPTURED_MAX_SCAN)).fetchall()
     seen, out, used = set(), [], 0
-    for r in rows:
+    for i, r in enumerate(rows):
+        if _past_floor(r, floor, i, scan):       # reached the last capture point / lean window
+            break
         content = r["content"] or ""
         if not any(cue in content.lower() for cue in _DECISION_CUES):
             continue
@@ -676,12 +727,15 @@ def _uncaptured_count(conn, project, scan=25, cap=9):
     the same 'safe to clear?' signal `review` reports, kept light enough for the ambient status bar (a
     small bounded log scan + lexical capture-check, no embedder). Powers the live 'N to capture' nudge."""
     try:
-        rows = conn.execute("SELECT content FROM log WHERE project=? ORDER BY ts DESC LIMIT ?",
-                            (project, scan)).fetchall()
+        floor = _capture_floor(conn, project)
+        rows = conn.execute("SELECT ts, content FROM log WHERE project=? ORDER BY ts DESC LIMIT ?",
+                            (project, _UNCAPTURED_MAX_SCAN)).fetchall()
     except Exception:
         return 0
     seen, n = set(), 0
-    for r in rows:
+    for i, r in enumerate(rows):
+        if _past_floor(r, floor, i, scan):       # reached the last capture point / lean window
+            break
         content = r["content"] or ""
         if not any(cue in content.lower() for cue in _DECISION_CUES):
             continue

--- a/src/engrim/cli.py
+++ b/src/engrim/cli.py
@@ -35,8 +35,39 @@ import sys
 DEFAULT_DB = os.path.expanduser("~/.engrim/memory.db")
 TYPES = ("decision", "fact", "feedback", "state", "reference", "user")
 STATUSES = ("active", "superseded", "done")
+ORIGIN_AGENTS = ("antigravity", "claude-code", "cursor", "cli", "user")
 # priority for the session-boot pack: how-to-work-with-user first, then state, then the rest
 _PRIO = {"user": 0, "feedback": 1, "state": 2, "decision": 3, "fact": 4, "reference": 5}
+
+
+def _norm_agent(agent: str | None) -> str | None:
+    if not agent:
+        return None
+    a = agent.strip().lower()
+    if a in ("agy", "antigravity", "gemini"):
+        return "antigravity"
+    if a in ("claude", "claude_code", "claude-code"):
+        return "claude-code"
+    if a == "cursor":
+        return "cursor"
+    if a == "cli":
+        return "cli"
+    if a == "user":
+        return "user"
+    return a
+
+
+def _agent_display(agent: str | None) -> str:
+    if not agent:
+        return ""
+    m = {
+        "antigravity": "Antigravity",
+        "claude-code": "Claude Code",
+        "cursor": "Cursor",
+        "cli": "CLI",
+        "user": "User",
+    }
+    return m.get(agent.lower(), agent.title())
 
 
 def _now() -> str:
@@ -190,7 +221,8 @@ def _init(conn: sqlite3.Connection) -> None:
         CREATE TABLE IF NOT EXISTS memories (
             id INTEGER PRIMARY KEY, ts TEXT NOT NULL, project TEXT NOT NULL,
             type TEXT NOT NULL, summary TEXT NOT NULL, detail TEXT,
-            status TEXT NOT NULL DEFAULT 'active', tags TEXT, links TEXT, source TEXT
+            status TEXT NOT NULL DEFAULT 'active', tags TEXT, links TEXT, source TEXT,
+            origin_agent TEXT
         );
         CREATE INDEX IF NOT EXISTS idx_mem_project ON memories(project, status, ts);
         CREATE TABLE IF NOT EXISTS engrim_meta (
@@ -209,6 +241,13 @@ def _init(conn: sqlite3.Connection) -> None:
         );
         """
     )
+    # Migrate older `memories` tables without origin_agent column
+    cols_mem = {r[1] for r in conn.execute("PRAGMA table_info(memories)")}
+    if "origin_agent" not in cols_mem:
+        try:
+            conn.execute("ALTER TABLE memories ADD COLUMN origin_agent TEXT")
+        except sqlite3.OperationalError:
+            pass
     # Migrate older `log` tables (pre-raw column / global-unique msg_uuid) without losing rows.
     cols = {r[1] for r in conn.execute("PRAGMA table_info(log)")}
     if "raw" not in cols:
@@ -274,17 +313,18 @@ def _meta_set(conn, project, key, value):
 
 
 def add_memory(conn, *, project, type, summary, detail=None, status="active",
-               tags=None, links=None, source=None) -> int:
+               tags=None, links=None, source=None, origin_agent=None) -> int:
     """Insert one memory record and best-effort auto-embed it; return the new id.
 
     The shared write core behind both the `add` CLI command and the MCP server, so a
     record created either way is identical and immediately searchable by meaning.
     `tags`/`links` are lists (already normalized by the caller)."""
+    origin_agent = _norm_agent(origin_agent or os.environ.get("ENGRIM_ORIGIN_AGENT"))
     cur = conn.execute(
-        "INSERT INTO memories(ts,project,type,summary,detail,status,tags,links,source) "
-        "VALUES(?,?,?,?,?,?,?,?,?)",
+        "INSERT INTO memories(ts,project,type,summary,detail,status,tags,links,source,origin_agent) "
+        "VALUES(?,?,?,?,?,?,?,?,?,?)",
         (_now(), project, type, summary, detail, status,
-         json.dumps(tags or []), json.dumps(links or []), source),
+         json.dumps(tags or []), json.dumps(links or []), source, origin_agent),
     )
     conn.commit()
     # Auto-embed so the record is searchable by meaning immediately — no manual `engrim embed` step.
@@ -306,16 +346,19 @@ def cmd_add(conn, a) -> None:
         sys.exit("--summary cannot be empty")
     # --global writes to the user-layer that loads in every project; otherwise scope to the cwd's project.
     project = GLOBAL_PROJECT if getattr(a, "globl", False) else _resolve_project(a.project)
+    origin_agent = getattr(a, "origin_agent", None) or os.environ.get("ENGRIM_ORIGIN_AGENT") or "cli"
     new_id = add_memory(conn, project=project, type=a.type, summary=a.summary,
                         detail=a.detail, status=a.status,
-                        tags=_csv(a.tags), links=_csv(a.links), source=a.source)
+                        tags=_csv(a.tags), links=_csv(a.links), source=a.source,
+                        origin_agent=origin_agent)
     shown = "global · loads in every project" if project == GLOBAL_PROJECT else project
     print(f"+ #{new_id} [{a.type}] {shown}\n  {a.summary}")
 
 
 def _row_line(r, detail: bool) -> str:
     tags = ", ".join(json.loads(r["tags"] or "[]"))
-    head = f"#{r['id']} [{r['type']}/{r['status']}] {r['ts'][:16]}  {r['summary']}"
+    via = f" (via {_agent_display(r['origin_agent'])})" if ("origin_agent" in r.keys() and r["origin_agent"]) else ""
+    head = f"#{r['id']} [{r['type']}/{r['status']}]{via} {r['ts'][:16]}  {r['summary']}"
     if tags:
         head += f"   ({tags})"
     if detail and r["detail"]:
@@ -966,7 +1009,10 @@ def cmd_context(conn, a) -> None:
         def _line(r, summ):
             tags = ", ".join(json.loads(r["tags"] or "[]"))
             gtag = "  · global" if r["project"] == GLOBAL_PROJECT else ""   # rides along in every project
-            print(f"- #{r['id']} {summ}" + (f"  ({tags})" if tags else "") + gtag)
+            via = f" (via {_agent_display(r['origin_agent'])})" if ("origin_agent" in r.keys() and r["origin_agent"]) else ""
+            type_tag = f" [{r['type'].upper()}]" if via else ""
+            colon = ":" if via else ""
+            print(f"- #{r['id']}{type_tag}{via}{colon} {summ}" + (f"  ({tags})" if tags else "") + gtag)
 
         # The resume cursor leads, in its own section, so a fresh session reads "where we left off" first.
         cursor = next(((r, s) for r, s in picked if _is_resume(r)), None)
@@ -1023,6 +1069,18 @@ def cmd_context(conn, a) -> None:
 
 
 def cmd_hook(conn, a) -> None:
+    agent = getattr(a, "agent", "claude") or "claude"
+    if agent in ("agy", "antigravity"):
+        from engrim.adapters.agy import handle_boot, handle_stop
+        event = getattr(a, "event", None) or "boot"
+        if event == "boot":
+            handle_boot(db_path=getattr(a, "db", None))
+        elif event == "stop":
+            handle_stop(db_path=getattr(a, "db", None))
+        else:
+            sys.exit(f"Unknown event {event} for agent {agent}")
+        return
+
     import contextlib
     import io
     # ONE-TIME context build: the very first session for a project seeds the store from Claude
@@ -1170,36 +1228,185 @@ def _verify_hook_bin(engrim_bin: str):
     return None
 
 
-def cmd_setup(conn, a) -> None:
-    """White-glove: wire the full SessionStart+SessionEnd loop into Claude Code settings.
+CANONICAL_AGY_SKILL = """---
+name: engrim
+description: Cross-session memory and context continuity for heavy, long-horizon work. Use to recall prior decisions, facts, feedback, and architecture rationale, or to save new durable project decisions across session clears.
+---
 
-    SessionStart `engrim hook`  -> mirror file-memory in, then inject the boot pack (start oriented).
-    SessionEnd  `engrim sync --claude` -> mirror the session's file-memory writes into the store.
-    Together these keep the SQLite store and Claude Code's md memory in lockstep, session in/out."""
-    settings_path = os.path.expanduser(a.settings or "~/.claude/settings.json")
-    engrim_bin = _hook_bin(shutil.which("engrim") or "engrim")
-    bin_error = _verify_hook_bin(engrim_bin)   # before wiring: never claim a hook that can't run
+# Engrim: Cross-Session Memory & Context Continuity
+
+Engrim provides persistent, project-scoped memory across agent sessions. It allows you to externalize architectural decisions, facts, and milestones so you can clear context freely without losing the "why" behind past decisions.
+
+---
+
+## Direct MCP Tools (Recommended)
+
+When Engrim MCP server is active, use these tools directly:
+
+- `engrim_recall(query, project="auto", k=5, type=None)`:
+  Run hybrid (keyword + semantic) search over project memory.
+- `engrim_context(project="auto", budget=4000)`:
+  Fetch the session-boot memory pack (high-signal active records).
+- `engrim_add(type, summary, detail=None, tags=[])`:
+  Save a durable record into Engrim memory.
+  `type` must be one of: `decision`, `fact`, `feedback`, `state`, `user`, `reference`.
+- `engrim_review(project="auto")`:
+  Check coverage before clearing context: surface recent decisions from the transcript log.
+
+---
+
+## CLI Commands
+
+You can also run Engrim via `run_command` in bash:
+
+```bash
+# Add a durable decision
+engrim add -t decision -s "Chose Postgres over Mongo" --tags db
+
+# Query memory for relevant records
+engrim recall -q "database architecture"
+
+# View active boot pack context
+engrim context
+
+# Check if recent decisions are safe before clearing
+engrim review
+
+# Perform doctor health check
+engrim doctor
+```
+
+---
+
+## Session Continuity Best Practices
+
+1. **Capture as you work**: Whenever a major decision, architecture choice, or milestone is established, call `engrim_add` (or `engrim add`).
+2. **Use `resume-pointer`**: Before clearing context or wrapping up a session, add a record tagged `resume-pointer` summarizing the immediate next step. The newest `resume-pointer` will be pinned to the top of the next session's boot pack!
+3. **Clear freely**: Once decisions are in Engrim, context can be safely cleared (`/clear`), as Engrim will inject the active memory pack at the start of the next session.
+"""
+
+
+def _setup_agy(engrim_bin: str, dry_run: bool = False) -> None:
+    print("Wiring Google Antigravity environment…")
+    hooks_path = os.path.expanduser("~/.gemini/config/hooks.json")
+    boot_cmd = f"{engrim_bin} hook --agent agy --event boot 2>/dev/null || true"
+    stop_cmd = f"{engrim_bin} hook --agent agy --event stop >/dev/null 2>&1 || true"
+    if dry_run:
+        print(f"[dry-run] Would wire Antigravity hooks in {hooks_path}:")
+        print(f"    PreInvocation: {boot_cmd}")
+        print(f"    Stop:          {stop_cmd}")
+    else:
+        os.makedirs(os.path.dirname(hooks_path), exist_ok=True)
+        hooks_data = {}
+        if os.path.exists(hooks_path):
+            try:
+                with open(hooks_path, "r", encoding="utf-8") as f:
+                    hooks_data = json.load(f)
+            except Exception:
+                hooks_data = {}
+        engrim_entry = hooks_data.setdefault("engrim", {})
+        engrim_entry["PreInvocation"] = [{"type": "command", "command": boot_cmd, "timeout": 30}]
+        engrim_entry["Stop"] = [{"type": "command", "command": stop_cmd, "timeout": 30}]
+        tmp = hooks_path + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(hooks_data, f, indent=2)
+        os.replace(tmp, hooks_path)
+        print(f"✓ wired PreInvocation & Stop hooks in {hooks_path}")
+
+    skill_path = os.path.expanduser("~/.gemini/config/skills/engrim/SKILL.md")
+    if dry_run:
+        print(f"[dry-run] Would deploy canonical Antigravity skill to {skill_path}")
+    else:
+        os.makedirs(os.path.dirname(skill_path), exist_ok=True)
+        tmp = skill_path + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            f.write(CANONICAL_AGY_SKILL)
+        os.replace(tmp, skill_path)
+        print(f"✓ deployed canonical Antigravity skill to {skill_path}")
+
+    mcp_paths = [
+        os.path.expanduser("~/.gemini/antigravity-cli/mcp_config.json"),
+        os.path.expanduser("~/.gemini/config/mcp_config.json"),
+    ]
+    raw_bin = engrim_bin.strip('"')
+    mcp_entry = {
+        "command": raw_bin,
+        "args": ["serve", "--mcp"],
+    }
+    for mp in mcp_paths:
+        if dry_run:
+            print(f"[dry-run] Would register MCP server in {mp}")
+        else:
+            os.makedirs(os.path.dirname(mp), exist_ok=True)
+            cfg = {}
+            if os.path.exists(mp):
+                try:
+                    with open(mp, "r", encoding="utf-8") as f:
+                        cfg = json.load(f)
+                except Exception:
+                    cfg = {}
+            servers = cfg.setdefault("mcpServers", {})
+            servers["engrim"] = mcp_entry
+            tmp = mp + ".tmp"
+            with open(tmp, "w", encoding="utf-8") as f:
+                json.dump(cfg, f, indent=2)
+            os.replace(tmp, mp)
+            print(f"✓ registered MCP server in {mp}")
+
+
+def _setup_cursor(engrim_bin: str, dry_run: bool = False) -> None:
+    print("Wiring Cursor MCP environment…")
+    cursor_mcp = os.path.expanduser("~/.cursor/mcp.json")
+    raw_bin = engrim_bin.strip('"')
+    mcp_entry = {
+        "command": raw_bin,
+        "args": ["serve", "--mcp"],
+    }
+    if dry_run:
+        print(f"[dry-run] Would register engrim in {cursor_mcp}")
+    else:
+        os.makedirs(os.path.dirname(cursor_mcp), exist_ok=True)
+        cfg = {}
+        if os.path.exists(cursor_mcp):
+            try:
+                with open(cursor_mcp, "r", encoding="utf-8") as f:
+                    cfg = json.load(f)
+            except Exception:
+                cfg = {}
+        servers = cfg.setdefault("mcpServers", {})
+        servers["engrim"] = mcp_entry
+        tmp = cursor_mcp + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(cfg, f, indent=2)
+        os.replace(tmp, cursor_mcp)
+        print(f"✓ registered Cursor MCP entry in {cursor_mcp}")
+
+
+def _setup_claude(conn, a, engrim_bin: str, dry_run: bool = False) -> None:
+    print("Wiring Claude Code environment…")
+    settings_path = os.path.expanduser(getattr(a, "settings", None) or "~/.claude/settings.json")
+    bin_error = _verify_hook_bin(engrim_bin)
     wired = {
         "SessionStart": (f"{engrim_bin} hook 2>/dev/null || true", "engrim hook"),
         "SessionEnd":   (f"{engrim_bin} sync --claude >/dev/null 2>&1 || true", "engrim sync"),
-        # Tail the transcript into the append-only log after each turn — cheap, never loaded.
         "Stop":         (f"{engrim_bin} log --hook >/dev/null 2>&1 || true", "engrim log"),
-        # The minder: auto-inject the relevant db slice for each prompt (top-k, budget-capped).
         "UserPromptSubmit": (f"{engrim_bin} assist 2>/dev/null || true", "engrim assist"),
     }
+
+    if dry_run:
+        print(f"[dry-run] Would wire Claude Code hooks in {settings_path}")
+        return
 
     os.makedirs(os.path.dirname(settings_path), exist_ok=True)
     settings = {}
     if os.path.exists(settings_path):
         try:
-            with open(settings_path, encoding="utf-8") as f:   # never the Windows locale codec
+            with open(settings_path, encoding="utf-8") as f:
                 settings = json.load(f)
         except json.JSONDecodeError as e:
             sys.exit(f"settings.json exists but is not valid JSON ({e}). Fix it, then re-run.")
         except OSError as e:
             sys.exit(f"can't read {settings_path} ({e}). Fix the permissions, then re-run.")
-        # Anything else (a decode error under a legacy locale, say) must not be reported as bad JSON:
-        # blaming a file the user hasn't touched sends them to fix something that isn't broken.
         except Exception as e:
             sys.exit(f"couldn't load {settings_path} ({type(e).__name__}: {e}). "
                      f"The file itself may be fine — please report this with the message above.")
@@ -1207,9 +1414,7 @@ def cmd_setup(conn, a) -> None:
     if bin_error:
         print(f"! the engrim command isn't runnable from a shell — {bin_error}\n"
               f"    tried: {engrim_bin} --help\n"
-              f"  Wiring the hooks anyway, but they will do NOTHING until this resolves. Usually it\n"
-              f"  means engrim isn't on PATH for the shell Claude Code runs hooks in. Fix that, then\n"
-              f"  re-run `engrim setup` — it's safe to run again and won't duplicate anything.\n")
+              f"  Wiring the hooks anyway, but they will do NOTHING until this resolves.\n")
 
     hooks = settings.setdefault("hooks", {})
     changed = False
@@ -1224,8 +1429,6 @@ def cmd_setup(conn, a) -> None:
             changed = True
             print(f"✓ wired {event} hook\n    {cmd}")
 
-    # Ambient status line: shows engrim is live + working in the status bar, never in the chat — so the
-    # user sees the benefit without being interrupted (the answer to "is this thing even doing anything?").
     sl, sl_cmd = settings.get("statusLine"), f"{engrim_bin} statusline"
     if isinstance(sl, dict) and _cmd_has(sl.get("command") or "", "engrim"):
         print("✓ status line already shows engrim")
@@ -1240,27 +1443,73 @@ def cmd_setup(conn, a) -> None:
         tmp = settings_path + ".engrim-tmp"
         with open(tmp, "w", encoding="utf-8") as f:
             json.dump(settings, f, indent=2)
-        os.replace(tmp, settings_path)  # atomic: never leave a half-written settings.json
+        os.replace(tmp, settings_path)
 
-    if not a.no_claude_md:
+    if not getattr(a, "no_claude_md", False):
         md_path = os.path.expanduser("~/.claude/CLAUDE.md")
         existing = ""
         if os.path.exists(md_path):
             with open(md_path, encoding="utf-8", errors="replace") as f:
-                existing = f.read()   # a CLAUDE.md full of emoji must not crash setup on Windows
+                existing = f.read()
         if "engrim" in existing and "Project Memory" in existing:
             print(f"✓ CLAUDE.md already mentions engrim ({md_path})")
         else:
+            os.makedirs(os.path.dirname(md_path), exist_ok=True)
             with open(md_path, "a", encoding="utf-8") as f:
                 if existing and not existing.endswith("\n"):
                     f.write("\n")
                 f.write("\n" + CLAUDE_MD_BLOCK)
             print(f"✓ added usage note to {md_path}")
 
-    # Warm the semantic backend now — a visible, one-time model fetch in a command the user is watching,
-    # so session hooks never cold-download mid-prompt. Then embed this project's existing records so the
-    # minder ranks by meaning from the very first session. All best-effort; never blocks setup.
-    if os.environ.get("ENGRIM_EMBED", "").strip().lower() not in ("0", "off", "none", "false", "no", "lexical"):
+
+def cmd_setup(conn, a) -> None:
+    """Universal multi-agent setup: Antigravity, Claude Code, and Cursor."""
+    engrim_bin = _hook_bin(shutil.which("engrim") or "engrim")
+    dry_run = getattr(a, "dry_run", False)
+    bin_error = _verify_hook_bin(engrim_bin)
+
+    explicit = bool(
+        getattr(a, "agy", False) or
+        getattr(a, "claude", False) or
+        getattr(a, "cursor", False) or
+        getattr(a, "all", False) or
+        getattr(a, "settings", None)
+    )
+
+    wire_agy = getattr(a, "agy", False) or getattr(a, "all", False)
+    wire_claude = getattr(a, "claude", False) or getattr(a, "all", False) or bool(getattr(a, "settings", None))
+    wire_cursor = getattr(a, "cursor", False) or getattr(a, "all", False)
+
+    if not explicit:
+        gemini_dir = os.path.expanduser("~/.gemini")
+        claude_dir = os.path.expanduser("~/.claude")
+        cursor_dir = os.path.expanduser("~/.cursor")
+        detected = []
+        if os.path.isdir(gemini_dir):
+            wire_agy = True
+            detected.append("Antigravity (~/.gemini)")
+        if os.path.isdir(claude_dir):
+            wire_claude = True
+            detected.append("Claude Code (~/.claude)")
+        if os.path.isdir(cursor_dir):
+            wire_cursor = True
+            detected.append("Cursor (~/.cursor)")
+
+        if detected:
+            print(f"Auto-detected environments: {', '.join(detected)}")
+        else:
+            print("No specific environment directories detected (~/.gemini, ~/.claude, ~/.cursor).")
+            print("Defaulting to Claude Code setup. (Use --agy, --cursor, or --all to wire others).")
+            wire_claude = True
+
+    if wire_agy:
+        _setup_agy(engrim_bin, dry_run=dry_run)
+    if wire_claude:
+        _setup_claude(conn, a, engrim_bin, dry_run=dry_run)
+    if wire_cursor:
+        _setup_cursor(engrim_bin, dry_run=dry_run)
+
+    if not dry_run and os.environ.get("ENGRIM_EMBED", "").strip().lower() not in ("0", "off", "none", "false", "no", "lexical"):
         print("\nPreparing semantic recall (first run downloads a small embedding model)…")
         fn, name = _resolve_embedder()
         if fn:
@@ -1285,16 +1534,17 @@ def cmd_setup(conn, a) -> None:
         else:
             print("• semantic recall unavailable (model2vec didn't load) — running pure-lexical for now")
 
-    if bin_error:   # last word, so it can't scroll past under the checkmarks
-        # sys.exit writes to stderr, which is unbuffered, while every checkmark above went to a
-        # stdout that is block-buffered whenever it isn't a terminal. Without this flush the final
-        # word lands FIRST under a pipe — correct-looking in a terminal, inverted everywhere else.
+    if wire_claude and bin_error and not dry_run:
         sys.stdout.flush()
         sys.exit(f"\nNOT done — the hooks are written, but `{engrim_bin} --help` fails in a shell "
                  f"({bin_error}),\nso every one of them will silently do nothing. Fix that and "
                  f"re-run `engrim setup`.")
-    print("\nDone. Open a NEW Claude Code session (or run /hooks to reload) and your project "
-          "memory will auto-load. Try: engrim add -t fact -s \"hello world\" ; engrim context")
+
+    if wire_claude and not dry_run:
+        print("\nDone. Open a NEW Claude Code session (or run /hooks to reload) and your project "
+              "memory will auto-load. Try: engrim add -t fact -s \"hello world\" ; engrim context")
+
+    print("\nUniversal memory setup complete.")
 
 
 _IMPORT_TYPE_MAP = {
@@ -1361,10 +1611,10 @@ def cmd_import(conn, a) -> None:
             continue
         tags = [t for t in re.split(r"[_\-.]", name) if len(t) > 1][:6]
         conn.execute(
-            "INSERT INTO memories(ts,project,type,summary,detail,status,tags,links,source) "
-            "VALUES(?,?,?,?,?,?,?,?,?)",
+            "INSERT INTO memories(ts,project,type,summary,detail,status,tags,links,source,origin_agent) "
+            "VALUES(?,?,?,?,?,?,?,?,?,?)",
             (_now(), project, typ, summary, body, "active",
-             json.dumps(tags), json.dumps([]), "import:" + base),
+             json.dumps(tags), json.dumps([]), "import:" + base, "cli"),
         )
         existing.add(summary)
         added += 1
@@ -1481,10 +1731,10 @@ def _do_sync(conn, project, path, hub="MEMORY.md", exclude=None, dry_run=False, 
             plan.append(("ADD", source, summary))
             if not dry_run:
                 conn.execute(
-                    "INSERT INTO memories(ts,project,type,summary,detail,status,tags,links,source)"
-                    " VALUES(?,?,?,?,?,?,?,?,?)",
+                    "INSERT INTO memories(ts,project,type,summary,detail,status,tags,links,source,origin_agent)"
+                    " VALUES(?,?,?,?,?,?,?,?,?,?)",
                     (_now(), project, typ, summary, detail, "active",
-                     json.dumps(tags), json.dumps([]), source))
+                     json.dumps(tags), json.dumps([]), source, "claude-code"))
             added += 1
         elif (row["summary"], row["detail"], row["type"], row["source"]) != (summary, detail, typ, source):
             plan.append(("UPD", source, summary))
@@ -1685,18 +1935,32 @@ def _ingest_transcript(conn, project, path, session=None, include_thinking=False
                 o = json.loads(line)
             except ValueError:
                 continue
-            if o.get("type") not in ("user", "assistant"):
+            otype = o.get("type")
+            osource = o.get("source")
+            if otype in ("user", "assistant"):
+                role = otype
+                msg = o.get("message") or {}
+                text = _extract_text(msg.get("content"), include_thinking)
+                uuid = o.get("uuid")
+                ts = o.get("timestamp") or _now()
+                sess = o.get("sessionId") or session
+            elif otype in ("USER_INPUT", "PLANNER_RESPONSE") or osource in ("USER_EXPLICIT", "MODEL"):
+                role = "user" if (otype == "USER_INPUT" or osource == "USER_EXPLICIT") else "assistant"
+                text = o.get("content") or ""
+                if not text and o.get("thinking") and include_thinking:
+                    text = "[thinking] " + o.get("thinking")
+                uuid = f"{session or 'agy'}-{o.get('step_index', '')}" if o.get("step_index") is not None else None
+                ts = o.get("created_at") or _now()
+                sess = session
+            else:
                 continue
             # Full fidelity: keep the complete original JSON line in `raw` (every turn, including
             # tool turns and sidechains), plus an extracted text slice in `content` for readable
             # search. raw never enters context, so completeness costs disk, not tokens.
-            msg = o.get("message") or {}
-            text = _extract_text(msg.get("content"), include_thinking)
             cur = conn.execute(
                 "INSERT OR IGNORE INTO log(ts,project,session,role,content,raw,msg_uuid) "
                 "VALUES(?,?,?,?,?,?,?)",
-                (o.get("timestamp") or _now(), project, o.get("sessionId") or session,
-                 o.get("type"), text, line, o.get("uuid")))
+                (ts, project, sess, role, text, line, uuid))
             added += cur.rowcount
         end = f.tell()
     # Advance the cursor monotonically. When start==0 we deliberately re-read from the top (new
@@ -2142,6 +2406,9 @@ def build_parser() -> argparse.ArgumentParser:
     pa.add_argument("--tags")
     pa.add_argument("--links")
     pa.add_argument("--source")
+    pa.add_argument("--origin-agent", "--agent", dest="origin_agent",
+                    choices=ORIGIN_AGENTS,
+                    help="Origin agent for provenance tracking (default: cli)")
     pa.set_defaults(func=cmd_add)
 
     pr = sub.add_parser("recall")
@@ -2172,11 +2439,15 @@ def build_parser() -> argparse.ArgumentParser:
     pc.add_argument("--json", action="store_true")
     pc.set_defaults(func=cmd_context)
 
-    ph = sub.add_parser("hook")
+    ph = sub.add_parser("hook", help="Lifecycle hook JSON for Claude Code / Antigravity")
     ph.add_argument("-p", "--project", default="auto")
     ph.add_argument("-b", "--budget", type=int, default=4000)
     ph.add_argument("--no-sync", action="store_true",
                     help="don't mirror Claude Code's file-memory before injecting")
+    ph.add_argument("--agent", choices=["claude", "agy", "antigravity"], default="claude",
+                    help="Target agent environment (default: claude)")
+    ph.add_argument("--event", choices=["boot", "stop", "sessionstart"], default=None,
+                    help="Hook lifecycle event (default: boot or sessionstart)")
     ph.set_defaults(func=cmd_hook)
 
     ps = sub.add_parser("supersede")
@@ -2184,7 +2455,17 @@ def build_parser() -> argparse.ArgumentParser:
     ps.add_argument("--status", default="superseded")
     ps.set_defaults(func=cmd_supersede)
 
-    pse = sub.add_parser("setup")
+    pse = sub.add_parser("setup", help="wire engrim into agent environments (Antigravity, Claude, Cursor)")
+    pse.add_argument("--agy", "--antigravity", dest="agy", action="store_true",
+                     help="wire Antigravity hooks, deploy skill, and register MCP server")
+    pse.add_argument("--claude", dest="claude", action="store_true",
+                     help="wire Claude Code SessionStart/Stop hooks and CLAUDE.md")
+    pse.add_argument("--cursor", dest="cursor", action="store_true",
+                     help="add engrim MCP entry to Cursor mcp.json")
+    pse.add_argument("--all", dest="all", action="store_true",
+                     help="configure all detected agent environments")
+    pse.add_argument("--dry-run", action="store_true",
+                     help="display planned configurations without modifying disk")
     pse.add_argument("--settings", help="path to settings.json (default ~/.claude/settings.json)")
     pse.add_argument("--no-claude-md", action="store_true", help="don't touch ~/.claude/CLAUDE.md")
     pse.set_defaults(func=cmd_setup)
@@ -2266,11 +2547,21 @@ def build_parser() -> argparse.ArgumentParser:
 
     pmcp = sub.add_parser("mcp", help="run engrim as an MCP server (stdio) for clients like Claude Code")
     pmcp.set_defaults(func=cmd_mcp)
+
+    psv = sub.add_parser("serve", help="serve engrim over stdio (e.g. --mcp)")
+    psv.add_argument("--mcp", action="store_true", default=True, help="run engrim as an MCP server over stdio")
+    psv.set_defaults(func=cmd_serve)
     return p
 
 
 def cmd_mcp(conn, a) -> None:
     """Run engrim as an MCP server over stdio (for MCP clients like Claude Code)."""
+    from engrim.mcp_server import serve
+    serve(conn)
+
+
+def cmd_serve(conn, a) -> None:
+    """Run engrim as an MCP server over stdio."""
     from engrim.mcp_server import serve
     serve(conn)
 

--- a/src/engrim/cli.py
+++ b/src/engrim/cli.py
@@ -1472,6 +1472,8 @@ def cmd_setup(conn, a) -> None:
         getattr(a, "agy", False) or
         getattr(a, "claude", False) or
         getattr(a, "cursor", False) or
+        getattr(a, "codex", False) or
+        getattr(a, "codex", False) or
         getattr(a, "all", False) or
         getattr(a, "settings", None)
     )
@@ -1479,11 +1481,14 @@ def cmd_setup(conn, a) -> None:
     wire_agy = getattr(a, "agy", False) or getattr(a, "all", False)
     wire_claude = getattr(a, "claude", False) or getattr(a, "all", False) or bool(getattr(a, "settings", None))
     wire_cursor = getattr(a, "cursor", False) or getattr(a, "all", False)
+    wire_codex = getattr(a, "codex", False) or getattr(a, "all", False)
+    wire_codex = getattr(a, "codex", False) or getattr(a, "all", False)
 
     if not explicit:
         gemini_dir = os.path.expanduser("~/.gemini")
         claude_dir = os.path.expanduser("~/.claude")
         cursor_dir = os.path.expanduser("~/.cursor")
+        codex_dir = os.path.expanduser("~/.codex")
         detected = []
         if os.path.isdir(gemini_dir):
             wire_agy = True
@@ -1494,12 +1499,15 @@ def cmd_setup(conn, a) -> None:
         if os.path.isdir(cursor_dir):
             wire_cursor = True
             detected.append("Cursor (~/.cursor)")
+        if os.path.isdir(codex_dir):
+            wire_codex = True
+            detected.append("Codex CLI (~/.codex)")
 
         if detected:
             print(f"Auto-detected environments: {', '.join(detected)}")
         else:
-            print("No specific environment directories detected (~/.gemini, ~/.claude, ~/.cursor).")
-            print("Defaulting to Claude Code setup. (Use --agy, --cursor, or --all to wire others).")
+            print("No specific environment directories detected (~/.gemini, ~/.claude, ~/.cursor, ~/.codex).")
+            print("Defaulting to Claude Code setup. (Use --agy, --cursor, --codex, or --all to wire others).")
             wire_claude = True
 
     if wire_agy:
@@ -1508,6 +1516,8 @@ def cmd_setup(conn, a) -> None:
         _setup_claude(conn, a, engrim_bin, dry_run=dry_run)
     if wire_cursor:
         _setup_cursor(engrim_bin, dry_run=dry_run)
+    if wire_codex:
+        _setup_codex(engrim_bin, dry_run=dry_run)
 
     if not dry_run and os.environ.get("ENGRIM_EMBED", "").strip().lower() not in ("0", "off", "none", "false", "no", "lexical"):
         print("\nPreparing semantic recall (first run downloads a small embedding model)…")
@@ -1545,6 +1555,176 @@ def cmd_setup(conn, a) -> None:
               "memory will auto-load. Try: engrim add -t fact -s \"hello world\" ; engrim context")
 
     print("\nUniversal memory setup complete.")
+
+
+
+def cmd_uninstall(conn, a) -> None:
+    """Universal multi-agent uninstall: Antigravity, Claude Code, and Cursor."""
+    dry_run = getattr(a, "dry_run", False)
+    explicit = bool(
+        getattr(a, "agy", False) or
+        getattr(a, "claude", False) or
+        getattr(a, "cursor", False) or
+        getattr(a, "all", False) or
+        getattr(a, "settings", None)
+    )
+
+    wire_agy = getattr(a, "agy", False) or getattr(a, "all", False)
+    wire_claude = getattr(a, "claude", False) or getattr(a, "all", False) or bool(getattr(a, "settings", None))
+    wire_cursor = getattr(a, "cursor", False) or getattr(a, "all", False)
+
+    if not explicit:
+        gemini_dir = os.path.expanduser("~/.gemini")
+        claude_dir = os.path.expanduser("~/.claude")
+        cursor_dir = os.path.expanduser("~/.cursor")
+        codex_dir = os.path.expanduser("~/.codex")
+        detected = []
+        if os.path.isdir(gemini_dir):
+            wire_agy = True
+            detected.append("Antigravity (~/.gemini)")
+        if os.path.isdir(claude_dir):
+            wire_claude = True
+            detected.append("Claude Code (~/.claude)")
+        if os.path.isdir(cursor_dir):
+            wire_cursor = True
+            detected.append("Cursor (~/.cursor)")
+        if os.path.isdir(codex_dir):
+            wire_codex = True
+            detected.append("Codex CLI (~/.codex)")
+
+        if detected:
+            print(f"Auto-detected environments: {', '.join(detected)}")
+        else:
+            print("No specific environment directories detected (~/.gemini, ~/.claude, ~/.cursor, ~/.codex).")
+            print("Defaulting to Claude Code uninstall. (Use --agy, --cursor, --codex, or --all to specify others).")
+            wire_claude = True
+
+    if wire_agy:
+        _uninstall_agy(dry_run=dry_run)
+    if wire_claude:
+        _uninstall_claude(a, dry_run=dry_run)
+    if wire_cursor:
+        _uninstall_cursor(dry_run=dry_run)
+    if wire_codex:
+        _uninstall_codex(dry_run=dry_run)
+        
+    print("\nUniversal memory uninstall complete.")
+
+def _uninstall_agy(dry_run: bool = False) -> None:
+    print("Unwiring Google Antigravity environment…")
+    hooks_path = os.path.expanduser("~/.gemini/config/hooks.json")
+    if dry_run:
+        print(f"[dry-run] Would unwire Antigravity hooks in {hooks_path}")
+    else:
+        if os.path.exists(hooks_path):
+            with open(hooks_path, "r", encoding="utf-8") as f:
+                hooks_data = json.load(f)
+            if "engrim" in hooks_data:
+                del hooks_data["engrim"]
+                tmp = hooks_path + ".tmp"
+                with open(tmp, "w", encoding="utf-8") as f:
+                    json.dump(hooks_data, f, indent=2)
+                os.replace(tmp, hooks_path)
+                print(f"✓ unwired PreInvocation & Stop hooks in {hooks_path}")
+            else:
+                print(f"✓ hooks already unwired in {hooks_path}")
+
+    skill_dir = os.path.expanduser("~/.gemini/config/skills/engrim")
+    if dry_run:
+        print(f"[dry-run] Would remove Antigravity skill directory {skill_dir}")
+    else:
+        if os.path.exists(skill_dir):
+            shutil.rmtree(skill_dir, ignore_errors=True)
+            print(f"✓ removed Antigravity skill directory {skill_dir}")
+        else:
+            print(f"✓ skill already removed {skill_dir}")
+
+    mcp_paths = [
+        os.path.expanduser("~/.gemini/antigravity-cli/mcp_config.json"),
+        os.path.expanduser("~/.gemini/config/mcp_config.json"),
+    ]
+    for mp in mcp_paths:
+        if dry_run:
+            print(f"[dry-run] Would remove MCP server from {mp}")
+        else:
+            if os.path.exists(mp):
+                with open(mp, "r", encoding="utf-8") as f:
+                    cfg = json.load(f)
+                servers = cfg.get("mcpServers", {})
+                if "engrim" in servers:
+                    del servers["engrim"]
+                    tmp = mp + ".tmp"
+                    with open(tmp, "w", encoding="utf-8") as f:
+                        json.dump(cfg, f, indent=2)
+                    os.replace(tmp, mp)
+                    print(f"✓ removed MCP server from {mp}")
+                else:
+                    print(f"✓ MCP server already removed from {mp}")
+
+def _uninstall_cursor(dry_run: bool = False) -> None:
+    print("Unwiring Cursor MCP environment…")
+    cursor_mcp = os.path.expanduser("~/.cursor/mcp.json")
+    if dry_run:
+        print(f"[dry-run] Would remove engrim from {cursor_mcp}")
+    else:
+        if os.path.exists(cursor_mcp):
+            with open(cursor_mcp, "r", encoding="utf-8") as f:
+                cfg = json.load(f)
+            servers = cfg.get("mcpServers", {})
+            if "engrim" in servers:
+                del servers["engrim"]
+                tmp = cursor_mcp + ".tmp"
+                with open(tmp, "w", encoding="utf-8") as f:
+                    json.dump(cfg, f, indent=2)
+                os.replace(tmp, cursor_mcp)
+                print(f"✓ removed Cursor MCP entry from {cursor_mcp}")
+            else:
+                print(f"✓ Cursor MCP entry already removed from {cursor_mcp}")
+
+def _uninstall_claude(a, dry_run: bool = False) -> None:
+    print("Unwiring Claude Code environment…")
+    settings_path = os.path.expanduser(getattr(a, "settings", None) or "~/.claude/settings.json")
+    if dry_run:
+        print(f"[dry-run] Would unwire Claude Code hooks in {settings_path}")
+        return
+
+    if os.path.exists(settings_path):
+        with open(settings_path, encoding="utf-8") as f:
+            settings = json.load(f)
+        hooks = settings.get("hooks", {})
+        changed = False
+        
+        events = ["SessionStart", "SessionEnd", "Stop", "UserPromptSubmit"]
+        for event in events:
+            if event in hooks:
+                groups = hooks[event]
+                new_groups = []
+                for grp in groups:
+                    new_hooks = [h for h in grp.get("hooks", []) if not _cmd_has(h.get("command", ""), "engrim")]
+                    if len(new_hooks) != len(grp.get("hooks", [])):
+                        changed = True
+                    if new_hooks:
+                        grp["hooks"] = new_hooks
+                        new_groups.append(grp)
+                if len(new_groups) != len(groups):
+                    changed = True
+                hooks[event] = new_groups
+                if not hooks[event]:
+                    del hooks[event]
+                    
+        sl = settings.get("statusLine")
+        if isinstance(sl, dict) and _cmd_has(sl.get("command", ""), "engrim"):
+            del settings["statusLine"]
+            changed = True
+            
+        if changed:
+            tmp = settings_path + ".engrim-tmp"
+            with open(tmp, "w", encoding="utf-8") as f:
+                json.dump(settings, f, indent=2)
+            os.replace(tmp, settings_path)
+            print(f"✓ unwired hooks and status line from {settings_path}")
+        else:
+            print(f"✓ hooks and status line already unwired from {settings_path}")
 
 
 _IMPORT_TYPE_MAP = {
@@ -2462,13 +2642,33 @@ def build_parser() -> argparse.ArgumentParser:
                      help="wire Claude Code SessionStart/Stop hooks and CLAUDE.md")
     pse.add_argument("--cursor", dest="cursor", action="store_true",
                      help="add engrim MCP entry to Cursor mcp.json")
+    pse.add_argument("--codex", dest="codex", action="store_true",
+                     help="wire Codex CLI hooks and MCP")
     pse.add_argument("--all", dest="all", action="store_true",
                      help="configure all detected agent environments")
     pse.add_argument("--dry-run", action="store_true",
                      help="display planned configurations without modifying disk")
     pse.add_argument("--settings", help="path to settings.json (default ~/.claude/settings.json)")
+    
     pse.add_argument("--no-claude-md", action="store_true", help="don't touch ~/.claude/CLAUDE.md")
     pse.set_defaults(func=cmd_setup)
+
+    pun = sub.add_parser("uninstall", help="remove engrim from agent environments (Antigravity, Claude, Cursor)")
+    pun.add_argument("--agy", "--antigravity", dest="agy", action="store_true",
+                     help="remove Antigravity hooks, skill, and MCP server")
+    pun.add_argument("--claude", dest="claude", action="store_true",
+                     help="remove Claude Code hooks and statusLine")
+    pun.add_argument("--cursor", dest="cursor", action="store_true",
+                     help="remove engrim MCP entry from Cursor mcp.json")
+    pun.add_argument("--codex", dest="codex", action="store_true",
+                     help="remove Codex CLI hooks and MCP")
+    pun.add_argument("--all", dest="all", action="store_true",
+                     help="remove from all detected agent environments")
+    pun.add_argument("--dry-run", action="store_true",
+                     help="display planned configurations without modifying disk")
+    pun.add_argument("--settings", help="path to settings.json (default ~/.claude/settings.json)")
+    pun.set_defaults(func=cmd_uninstall)
+
 
     pi = sub.add_parser("import")
     pi.add_argument("path", help="a markdown file or a directory tree to import (one record per file)")

--- a/src/engrim/cli.py
+++ b/src/engrim/cli.py
@@ -84,7 +84,22 @@ def _resolve_project(p, cwd=None):
     if env:
         return env
     base = cwd or os.getcwd()
-    return _git_root(base) or base
+    return _norm_project(_git_root(base) or base)
+
+
+def _norm_project(path: str) -> str:
+    """Stabilise a path-derived project tag so one project can't split into two memory buckets.
+
+    Windows-only, and deliberately so: the tag is a dict key, and there the SAME directory arrives
+    spelled differently depending on who reports it — `C:\\p` from os.getcwd() vs `c:/p` from a hook
+    payload written by Claude Code. Separators and drive-letter case are the two ways that happens;
+    both normalise here, the rest of the path keeps its casing so output still reads naturally.
+    POSIX paths are returned untouched — they're already the one true spelling."""
+    if os.name != "nt" or not path:
+        return path
+    import ntpath          # == os.path on Windows; named explicitly so this is testable anywhere
+    drive, rest = ntpath.splitdrive(ntpath.normpath(path))
+    return drive.upper() + rest
 
 
 def _payload_project(payload, explicit=None):
@@ -1105,6 +1120,26 @@ Keep it high-signal — curation and retrieval precision are the point, not volu
 """
 
 
+def _hook_bin(path: str) -> str:
+    """Quote the resolved engrim path for the shell Claude Code runs hooks in.
+
+    On Windows `which` hands back `C:\\Users\\...\\Scripts\\engrim.EXE`; interpolated raw, bash reads
+    the backslashes as escapes and the command collapses to `C:UserstimgoAppData...` — not found.
+    The `2>/dev/null || true` then swallows the error, so every hook is a silent no-op while setup
+    still prints its green checkmarks. Forward slashes + quotes survive; quoting also fixes paths
+    with spaces on POSIX, which were equally broken and just rarer."""
+    return '"' + path.replace("\\", "/") + '"'
+
+
+def _cmd_has(command: str, marker: str) -> bool:
+    """Does an already-wired hook command carry this marker? Normalised so Windows spellings match.
+
+    `"C:/Users/.../engrim.EXE" hook` has to read as `engrim hook`, or re-running setup won't
+    recognise its own hooks and appends a duplicate group every time (setup is documented idempotent)."""
+    norm = command.replace("\\", "/").replace('"', "").replace("'", "").lower()
+    return marker in norm.replace(".exe", "")
+
+
 def cmd_setup(conn, a) -> None:
     """White-glove: wire the full SessionStart+SessionEnd loop into Claude Code settings.
 
@@ -1112,7 +1147,7 @@ def cmd_setup(conn, a) -> None:
     SessionEnd  `engrim sync --claude` -> mirror the session's file-memory writes into the store.
     Together these keep the SQLite store and Claude Code's md memory in lockstep, session in/out."""
     settings_path = os.path.expanduser(a.settings or "~/.claude/settings.json")
-    engrim_bin = shutil.which("engrim") or "engrim"
+    engrim_bin = _hook_bin(shutil.which("engrim") or "engrim")
     wired = {
         "SessionStart": (f"{engrim_bin} hook 2>/dev/null || true", "engrim hook"),
         "SessionEnd":   (f"{engrim_bin} sync --claude >/dev/null 2>&1 || true", "engrim sync"),
@@ -1126,7 +1161,7 @@ def cmd_setup(conn, a) -> None:
     settings = {}
     if os.path.exists(settings_path):
         try:
-            with open(settings_path) as f:
+            with open(settings_path, encoding="utf-8") as f:   # never the Windows locale codec
                 settings = json.load(f)
         except Exception as e:
             sys.exit(f"settings.json exists but is not valid JSON ({e}). Fix it, then re-run.")
@@ -1135,7 +1170,7 @@ def cmd_setup(conn, a) -> None:
     changed = False
     for event, (cmd, marker) in wired.items():
         groups = hooks.setdefault(event, [])
-        present = any(marker in h.get("command", "")
+        present = any(_cmd_has(h.get("command", ""), marker)
                       for grp in groups for h in grp.get("hooks", []))
         if present:
             print(f"✓ {event} hook already present in {settings_path}")
@@ -1147,7 +1182,7 @@ def cmd_setup(conn, a) -> None:
     # Ambient status line: shows engrim is live + working in the status bar, never in the chat — so the
     # user sees the benefit without being interrupted (the answer to "is this thing even doing anything?").
     sl, sl_cmd = settings.get("statusLine"), f"{engrim_bin} statusline"
-    if isinstance(sl, dict) and "engrim" in (sl.get("command") or ""):
+    if isinstance(sl, dict) and _cmd_has(sl.get("command") or "", "engrim"):
         print("✓ status line already shows engrim")
     elif sl:
         print(f"• a status line is already configured — leaving it. To show engrim, set its command to: {sl_cmd}")
@@ -1158,7 +1193,7 @@ def cmd_setup(conn, a) -> None:
 
     if changed:
         tmp = settings_path + ".engrim-tmp"
-        with open(tmp, "w") as f:
+        with open(tmp, "w", encoding="utf-8") as f:
             json.dump(settings, f, indent=2)
         os.replace(tmp, settings_path)  # atomic: never leave a half-written settings.json
 
@@ -1166,12 +1201,12 @@ def cmd_setup(conn, a) -> None:
         md_path = os.path.expanduser("~/.claude/CLAUDE.md")
         existing = ""
         if os.path.exists(md_path):
-            with open(md_path) as f:
-                existing = f.read()
+            with open(md_path, encoding="utf-8", errors="replace") as f:
+                existing = f.read()   # a CLAUDE.md full of emoji must not crash setup on Windows
         if "engrim" in existing and "Project Memory" in existing:
             print(f"✓ CLAUDE.md already mentions engrim ({md_path})")
         else:
-            with open(md_path, "a") as f:
+            with open(md_path, "a", encoding="utf-8") as f:
                 if existing and not existing.endswith("\n"):
                     f.write("\n")
                 f.write("\n" + CLAUDE_MD_BLOCK)
@@ -2188,6 +2223,17 @@ def cmd_mcp(conn, a) -> None:
 
 
 def main(argv=None) -> None:
+    # Windows defaults the std streams to cp1252 the moment they aren't a console — and Claude Code
+    # drives every hook and the status line through pipes. Two live failures came out of that:
+    # `statusline`/`context`/`stats` died with UnicodeEncodeError on the bar's leading 🧠, and stdin
+    # decoding broke the hooks that read a JSON payload (any emoji or smart quote in a prompt).
+    # Both look fine in a terminal, which is what makes them easy to ship. UTF-8 everywhere, and
+    # errors="replace" so an odd byte degrades to a glyph instead of taking the command down.
+    for stream in (sys.stdin, sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")
+        except Exception:
+            pass                       # not a TextIOWrapper (captured/redirected in-process) — fine
     args = build_parser().parse_args(argv)
     if getattr(args, "k", None) is not None:
         args.k = max(0, args.k)        # a negative LIMIT would dump the whole store

--- a/src/engrim/cli.py
+++ b/src/engrim/cli.py
@@ -355,6 +355,36 @@ def _recall_rows(conn, project, query, k, type_=None, include_stale=False):
     return conn.execute(sql, params).fetchall()
 
 
+def _log_search(conn, project, query, k):
+    """Search the transcript log — the 128 MB of history that `recall` never touches.
+
+    Deliberately OPT-IN (`recall --log`). The two-tier split (#98) is that the log never AUTO-loads
+    into context; asking for it explicitly doesn't violate that, it's the payoff for having kept it.
+    Plain scan, no FTS table: log.content is ~5 MB against 128 MB of raw, and a full scan measures at
+    ~21 ms over 44k rows — not worth an index, a migration, or the write amplification."""
+    terms = [t for t in _content_terms(query or "")] or [(query or "").strip().lower()]
+    terms = [t for t in terms if t]
+    if not terms:
+        return []
+    like = " AND ".join(["LOWER(content) LIKE ?"] * len(terms))
+    rows = conn.execute(
+        "SELECT ts, role, content FROM log WHERE project = ? AND content IS NOT NULL AND content != '' "
+        "AND " + like + " ORDER BY ts DESC LIMIT ?",
+        (project, *[f"%{t}%" for t in terms], k)).fetchall()
+    return rows
+
+
+def _log_hit_line(row, query):
+    """One result line: the matching slice of the turn, not the whole turn."""
+    content = " ".join((row["content"] or "").split())
+    terms = [t for t in _content_terms(query or "") if t]
+    low = content.lower()
+    at = min([low.find(t) for t in terms if low.find(t) >= 0] or [0])
+    start = max(0, at - 60)
+    snip = ("…" if start else "") + content[start:start + 180] + ("…" if len(content) > start + 180 else "")
+    return f"  · [{row['ts'][:16]}] {row['role']:<9} {snip}"
+
+
 def cmd_recall(conn, a) -> None:
     project = _resolve_project(a.project)
     # Hybrid (bm25 + semantic) for a real free-text query — same fusion the minder uses, so a manual
@@ -370,14 +400,24 @@ def cmd_recall(conn, a) -> None:
         clean = [{k: v for k, v in dict(r).items() if k not in ("rank", "_vec")} for r in rows]
         print(json.dumps(clean, default=str))
         return
-    if not rows:
+    if not rows and not getattr(a, "log", False):
         print(f"(no memories for project={project}"
               + (f" matching {a.query!r}" if a.query else "") + ")")
         return
-    print(f"== {len(rows)} memr(s) · project={project}"
-          + (f" · q={a.query!r}" if a.query else "") + " ==")
-    for r in rows:
-        print(_row_line(r, a.detail))
+    if rows:
+        print(f"== {len(rows)} memr(s) · project={project}"
+              + (f" · q={a.query!r}" if a.query else "") + " ==")
+        for r in rows:
+            print(_row_line(r, a.detail))
+    if getattr(a, "log", False):
+        hits = _log_search(conn, project, a.query, a.k)
+        print(f"\n== log · {len(hits)} turn(s)"
+              + (f" matching {a.query!r}" if a.query else "") + " ==")
+        if not hits:
+            print("  (nothing in the transcript log — it holds prose plus one line per "
+                  "state-changing action)")
+        for r in hits:
+            print(_log_hit_line(r, a.query))
 
 
 def cmd_list(conn, a) -> None:
@@ -1455,12 +1495,60 @@ def cmd_sync(conn, a) -> None:
 # it can't bloat a session or drag the system. Curated memory (small, loaded) and the transcript
 # log (complete, never loaded) are two tiers that don't compete.
 
+# --- action lines: the WORK, not just the talk ---------------------------------------------------
+#
+# The log used to keep prose only ("the actual conversation, not machinery"), which left it too
+# chat-focused: measured on one real session, prose was 14 KB against 315 KB of tool traffic, so the
+# record of what was actually DONE — files changed, releases cut — existed nowhere searchable (#756).
+#
+# The fix is a snippet of value per action, not the payload. A tool call becomes ONE line naming the
+# change; the 93 KB of tool_use in that session compresses to ~10 KB of readable spine. Deliberately
+# STATE-CHANGING only: greps, reads and inspection are how you find things, not what you did, and
+# including them buried the signal 4:1.
+_ACTION_PREFIXES = ("[changed]", "[ran]")
+_EDIT_TOOLS = ("Edit", "Write", "NotebookEdit")
+_STATE_CHANGING_CMD = re.compile(
+    r"(?:^|[;&|]\s*)\s*(?:sudo\s+)?("
+    r"git\s+(?:commit|push|tag|merge|rebase|reset|revert|cherry-pick)"
+    r"|gh\s+(?:release|pr)\s+create"
+    r"|(?:pip|pip3|uv|npm|pnpm|yarn|cargo|gem|brew|apt|apt-get)\s+"
+    r"(?:install|uninstall|add|remove|publish)"
+    r"|twine\s+upload"
+    r"|engrim\s+(?:add|supersede|import|sync)"
+    r"|mkdir|chmod|chown|ln\s+-s|rm\s|mv\s|cp\s"
+    r")", re.I)
+_ACTION_LINE_CAP = 160
+
+
+def _action_lines(blocks):
+    """One compact line per STATE-CHANGING tool call. Returns [] for pure investigation."""
+    out = []
+    for b in blocks:
+        if not isinstance(b, dict) or b.get("type") != "tool_use":
+            continue
+        name, inp = b.get("name"), b.get("input") or {}
+        if not isinstance(inp, dict):
+            continue
+        if name in _EDIT_TOOLS:
+            path = inp.get("file_path") or inp.get("notebook_path")
+            if path:
+                out.append(f"[changed] {path}")
+        elif name == "Bash":
+            cmd = " ".join((inp.get("command") or "").split())
+            if not cmd or not _STATE_CHANGING_CMD.search(cmd):
+                continue
+            desc = " ".join((inp.get("description") or "").split())
+            line = f"[ran] {desc} — {cmd}" if desc else f"[ran] {cmd}"
+            out.append(line[:_ACTION_LINE_CAP].rstrip())
+    return out
+
+
 def _extract_text(content, include_thinking=False):
-    """Pull the human-readable text out of a Claude transcript message's `content`.
+    """Pull the searchable text out of a Claude transcript message's `content`.
 
     `content` is a str (plain user prompt) or a list of typed blocks. We keep `text` (the visible
-    exchange), optionally `thinking`, and skip tool_use/tool_result/images so the log stays the
-    actual conversation, not machinery."""
+    exchange), optionally `thinking`, plus a one-line summary of each state-changing tool call
+    (see `_action_lines`). Tool RESULTS and images are still skipped — they're bulk, not signal."""
     if isinstance(content, str):
         return content.strip()
     if not isinstance(content, list):
@@ -1474,6 +1562,7 @@ def _extract_text(content, include_thinking=False):
             parts.append(b.get("text", ""))
         elif t == "thinking" and include_thinking:
             parts.append("[thinking] " + b.get("thinking", ""))
+    parts.extend(_action_lines(content))
     return "\n".join(p for p in parts if p).strip()
 
 
@@ -1557,6 +1646,27 @@ def cmd_log(conn, a) -> None:
                            payload.get("session_id"), a.include_thinking)
         return  # silent: this runs from a hook
     project = _resolve_project(a.project)
+    if getattr(a, "reindex", False):
+        # Re-derive `content` from the preserved `raw` for turns already on disk. Because raw was
+        # always kept in full, action lines can be recovered for the ENTIRE history — the feature
+        # doesn't start empty on a store with 44k turns behind it. Only ADDS extracted text; a turn
+        # whose re-extraction yields nothing keeps whatever it had.
+        n, changed = 0, 0
+        for r in conn.execute(
+                "SELECT id, content, raw FROM log WHERE project = ? AND raw IS NOT NULL",
+                (project,)).fetchall():
+            n += 1
+            try:
+                blocks = json.loads(r["raw"]).get("message", {}).get("content")
+            except Exception:
+                continue
+            fresh = _extract_text(blocks, a.include_thinking)
+            if fresh and fresh != (r["content"] or ""):
+                conn.execute("UPDATE log SET content = ? WHERE id = ?", (fresh, r["id"]))
+                changed += 1
+        conn.commit()
+        print(f"reindexed {n} turn(s) · {changed} gained text -> project={project}")
+        return
     if a.from_transcript:
         n = _ingest_transcript(conn, project, a.from_transcript, a.session, a.include_thinking)
         print(f"logged {n} new turn(s) from transcript -> project={project}")
@@ -1672,8 +1782,13 @@ def _decision_snippet(text, cues=_DECISION_CUES):
 def _looks_like_narration(snippet):
     """True if the snippet is the agent's own process/meta chatter rather than a project decision
     (#197). Drops it from the clear-readiness signal so 'to capture' counts real decisions only."""
-    low = (snippet or "").lower()
-    return any(m in low for m in _NARRATION_MARKERS)
+    s = (snippet or "").lstrip()
+    # Action lines are a record of WORK, not a decision to capture. They're searchable via
+    # `recall --log`, but they must never inflate the "to capture" nudge — the counter's precision is
+    # the whole reason it's trusted (#219, #747).
+    if s.startswith(_ACTION_PREFIXES):
+        return True
+    return any(m in s.lower() for m in _NARRATION_MARKERS)
 
 
 def _semantic_decision_snippet(content, fn, exemplar_vecs):
@@ -1949,6 +2064,9 @@ def build_parser() -> argparse.ArgumentParser:
     pr.add_argument("--detail", action="store_true")
     pr.add_argument("--include-stale", action="store_true")
     pr.add_argument("--json", action="store_true")
+    pr.add_argument("--log", action="store_true",
+                    help="also search the transcript log (prose + state-changing actions). Opt-in: "
+                         "the log never auto-loads into context, but it's searchable on demand")
     pr.set_defaults(func=cmd_recall)
 
     pl = sub.add_parser("list")
@@ -2013,6 +2131,9 @@ def build_parser() -> argparse.ArgumentParser:
     plog.add_argument("--from-transcript", help="ingest new turns from a Claude Code transcript JSONL")
     plog.add_argument("--hook", action="store_true",
                       help="read a Stop-hook JSON from stdin and ingest the session's new turns")
+    plog.add_argument("--reindex", action="store_true",
+                      help="re-derive searchable text from the raw turns already stored (recovers "
+                           "action lines for history logged before they existed)")
     plog.add_argument("--include-thinking", action="store_true",
                       help="also log assistant 'thinking' blocks (off by default; large + internal)")
     plog.set_defaults(func=cmd_log)

--- a/src/engrim/cli.py
+++ b/src/engrim/cli.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as _dt
+import hashlib
 import json
 import os
 import re
@@ -1709,6 +1710,61 @@ def _max_similarity(conn, project, text, fn):
 
 _UNSET = object()   # "caller didn't supply an embedder" — distinct from an explicit None ("lexical only")
 
+# Per-SNIPPET semantic verdict cache. The count-level memo alone isn't enough: its fingerprint includes
+# the newest log row, and a new row lands every single turn, so on a project with a live nag the first
+# status refresh after each turn paid a full ~1.2s model load. A verdict about "is THIS snippet already
+# curated?" only goes stale when the CURATED side changes — new log turns are irrelevant to it. So this
+# is keyed on curated state alone, which means the embedder loads once per genuinely new decision, not
+# once per turn. Bounded and stored as one small meta row; a curation change drops the whole map.
+_SEM_VERDICT_CAP = 96
+
+
+def _curated_state_key(conn, project):
+    """Fingerprint of the CURATED side only — what a captured-verdict actually depends on."""
+    row = conn.execute(
+        "SELECT MAX(ts), COUNT(*) FROM memories WHERE project=? AND status='active'",
+        (project,)).fetchone()
+    return f"{row[0]}|{row[1]}|{os.environ.get('ENGRIM_EMBED', '').strip().lower()}"
+
+
+def _snippet_key(snippet):
+    return hashlib.sha1((snippet or "").lower().encode("utf-8", "replace")).hexdigest()[:16]
+
+
+def _semantic_verdict_get(conn, project, snippet):
+    """(verdict, state) — verdict is None on a miss. `state` is handed back so the caller can store
+    under the same fingerprint it read, without recomputing it."""
+    try:
+        state = _curated_state_key(conn, project)
+    except Exception:
+        return None, None
+    try:
+        blob = _meta_get(conn, project, "cap_cache")
+        if blob:
+            d = json.loads(blob)
+            if d.get("k") == state:
+                v = d.get("v", {}).get(_snippet_key(snippet))
+                if v is not None:
+                    return bool(v), state
+    except Exception:
+        pass
+    return None, state
+
+
+def _semantic_verdict_put(conn, project, snippet, verdict, state):
+    if not state:
+        return
+    try:
+        blob = _meta_get(conn, project, "cap_cache")
+        d = json.loads(blob) if blob else {}
+        v = d.get("v", {}) if d.get("k") == state else {}     # curation moved -> start clean
+        if len(v) >= _SEM_VERDICT_CAP:
+            v = {}                                            # bounded; cheap to refill
+        v[_snippet_key(snippet)] = 1 if verdict else 0
+        _meta_set(conn, project, "cap_cache", json.dumps({"k": state, "v": v}))
+    except Exception:
+        pass                                                  # a read-only db must never break the bar
+
 
 def _is_captured(conn, project, snippet, fn=_UNSET):
     """THE definition of "this decision is already in curated memory". Every clear-readiness surface
@@ -1729,9 +1785,18 @@ def _is_captured(conn, project, snippet, fn=_UNSET):
     pass None to force pure-lexical."""
     if _lexical_overlap_captured(conn, project, snippet):
         return True
+    # Consult the verdict cache BEFORE resolving an embedder — resolving is what costs ~1s, so a
+    # lookup after it would save nothing.
+    cached, state = _semantic_verdict_get(conn, project, snippet)
+    if cached is not None:
+        return cached
     if fn is _UNSET:                    # not supplied -> resolve lazily (cached per process)
         fn, _ = _resolve_embedder()
-    return bool(fn) and _max_similarity(conn, project, snippet, fn) >= _CAPTURED_SIM
+    if not fn:
+        return False
+    verdict = _max_similarity(conn, project, snippet, fn) >= _CAPTURED_SIM
+    _semantic_verdict_put(conn, project, snippet, verdict, state)
+    return verdict
 
 
 def _lexical_overlap_captured(conn, project, snippet):

--- a/src/engrim/cli.py
+++ b/src/engrim/cli.py
@@ -53,15 +53,22 @@ _PROJECT_MARKERS = (".git", ".hg", ".svn", ".claude")
 def _git_root(start: str):
     """Walk up from `start` to the nearest project root (a dir with a _PROJECT_MARKER). None if none.
 
-    $HOME is NEVER treated as a project root: `~/.claude` (and a stray `~/.git`) exist for almost
-    everyone, so anchoring there would collapse every non-repo project under home into ONE bucket —
-    worse than the no-marker fallback. We skip the marker check AT home but keep walking past it, so a
-    real repo above home (unusual) still resolves while `~/.claude` can't become a catch-all anchor."""
-    home = os.path.realpath(os.path.expanduser("~"))
+    The walk STOPS AT $HOME and never climbs past it. `~/.claude` (and a stray `~/.git`) exist for
+    almost everyone, so anchoring AT home would collapse every non-repo project under it into ONE
+    bucket — worse than the no-marker fallback. Refusing to climb PAST home is what makes the tag
+    deterministic: it used to keep walking, so the answer depended on whatever happened to sit in
+    /home or C:\\Users on that particular machine, and a dev box with its own marker up there tagged
+    differently than a bare CI runner. A real repo above home no longer resolves and falls back to
+    the raw cwd tag — coarse, but never wrong, and that case needs a marker at /home or C:\\Users."""
+    # normcase, or the home guard fails open on Windows: `C:\Users\Tim` vs `c:/users/tim` are the same
+    # directory spelled two ways, and a missed match here is the exact collapse this guard prevents —
+    # every loose project under home in ONE bucket. No-op on POSIX, where case is significant.
+    home = os.path.normcase(os.path.realpath(os.path.expanduser("~")))
     cur = os.path.abspath(start)
     while True:
-        if os.path.realpath(cur) != home and \
-                any(os.path.exists(os.path.join(cur, m)) for m in _PROJECT_MARKERS):
+        if os.path.normcase(os.path.realpath(cur)) == home:
+            return None                 # home is not a root, and nothing above it is either
+        if any(os.path.exists(os.path.join(cur, m)) for m in _PROJECT_MARKERS):
             return cur
         parent = os.path.dirname(cur)
         if parent == cur:
@@ -1140,6 +1147,29 @@ def _cmd_has(command: str, marker: str) -> bool:
     return marker in norm.replace(".exe", "")
 
 
+def _verify_hook_bin(engrim_bin: str):
+    """Actually run the wired binary the way Claude Code will. Returns None if it works, else why not.
+
+    This is the missing feedback loop behind every silent Windows failure: the hook commands end in
+    `2>/dev/null || true` so a session is never broken by a bad hook, which also means a completely
+    non-functional install still prints a full column of green checkmarks. Setup is the one moment the
+    user is watching, so the checkmark gets earned here instead of assumed. Hooks run through bash on
+    every platform (Git Bash on Windows), so the check has to go through bash to be worth anything —
+    it is the shell quoting, not the binary, that broke."""
+    import subprocess              # local: `setup` runs once, the status line runs every refresh
+    shell = shutil.which("bash")
+    cmd = [shell, "-c", f"{engrim_bin} --help"] if shell else f"{engrim_bin} --help"
+    try:
+        p = subprocess.run(cmd, shell=not shell, capture_output=True, text=True,
+                           errors="replace", timeout=30)
+    except Exception as e:                       # no shell at all, or it couldn't be spawned
+        return f"couldn't run the command ({type(e).__name__}: {e})"
+    if p.returncode != 0:
+        detail = (p.stderr or p.stdout or "").strip().splitlines()
+        return (detail[-1] if detail else f"exit status {p.returncode}")
+    return None
+
+
 def cmd_setup(conn, a) -> None:
     """White-glove: wire the full SessionStart+SessionEnd loop into Claude Code settings.
 
@@ -1148,6 +1178,7 @@ def cmd_setup(conn, a) -> None:
     Together these keep the SQLite store and Claude Code's md memory in lockstep, session in/out."""
     settings_path = os.path.expanduser(a.settings or "~/.claude/settings.json")
     engrim_bin = _hook_bin(shutil.which("engrim") or "engrim")
+    bin_error = _verify_hook_bin(engrim_bin)   # before wiring: never claim a hook that can't run
     wired = {
         "SessionStart": (f"{engrim_bin} hook 2>/dev/null || true", "engrim hook"),
         "SessionEnd":   (f"{engrim_bin} sync --claude >/dev/null 2>&1 || true", "engrim sync"),
@@ -1163,8 +1194,22 @@ def cmd_setup(conn, a) -> None:
         try:
             with open(settings_path, encoding="utf-8") as f:   # never the Windows locale codec
                 settings = json.load(f)
-        except Exception as e:
+        except json.JSONDecodeError as e:
             sys.exit(f"settings.json exists but is not valid JSON ({e}). Fix it, then re-run.")
+        except OSError as e:
+            sys.exit(f"can't read {settings_path} ({e}). Fix the permissions, then re-run.")
+        # Anything else (a decode error under a legacy locale, say) must not be reported as bad JSON:
+        # blaming a file the user hasn't touched sends them to fix something that isn't broken.
+        except Exception as e:
+            sys.exit(f"couldn't load {settings_path} ({type(e).__name__}: {e}). "
+                     f"The file itself may be fine — please report this with the message above.")
+
+    if bin_error:
+        print(f"! the engrim command isn't runnable from a shell — {bin_error}\n"
+              f"    tried: {engrim_bin} --help\n"
+              f"  Wiring the hooks anyway, but they will do NOTHING until this resolves. Usually it\n"
+              f"  means engrim isn't on PATH for the shell Claude Code runs hooks in. Fix that, then\n"
+              f"  re-run `engrim setup` — it's safe to run again and won't duplicate anything.\n")
 
     hooks = settings.setdefault("hooks", {})
     changed = False
@@ -1240,6 +1285,14 @@ def cmd_setup(conn, a) -> None:
         else:
             print("• semantic recall unavailable (model2vec didn't load) — running pure-lexical for now")
 
+    if bin_error:   # last word, so it can't scroll past under the checkmarks
+        # sys.exit writes to stderr, which is unbuffered, while every checkmark above went to a
+        # stdout that is block-buffered whenever it isn't a terminal. Without this flush the final
+        # word lands FIRST under a pipe — correct-looking in a terminal, inverted everywhere else.
+        sys.stdout.flush()
+        sys.exit(f"\nNOT done — the hooks are written, but `{engrim_bin} --help` fails in a shell "
+                 f"({bin_error}),\nso every one of them will silently do nothing. Fix that and "
+                 f"re-run `engrim setup`.")
     print("\nDone. Open a NEW Claude Code session (or run /hooks to reload) and your project "
           "memory will auto-load. Try: engrim add -t fact -s \"hello world\" ; engrim context")
 

--- a/src/engrim/cli.py
+++ b/src/engrim/cli.py
@@ -2007,6 +2007,129 @@ def cmd_sync(conn, a) -> None:
             print(f"  {action:4} {source}\n         {summary[:80]}")
 
 
+# --------------------------------------------------------------------------- merge
+# Two stores of the same project meet whenever a project's agents run in more than one place — a
+# laptop and a CI runner, two machines, two agents at once — and each ends up holding decisions the
+# other lacks. `merge` folds OTHER's records into this store, idempotently, so both places can keep
+# writing and reconcile afterwards.
+#
+# Identity is content, not id. `memories.id` is assigned per store, so two stores seeded from the
+# same base hand the same id to different records; the natural key is
+# (project, ts, type, summary, detail) — ts is to the second with a zone, and nothing ever rewrites
+# a record's text (`supersede` changes status only). Status is monotonic: active -> superseded/done
+# is the only mutation engrim makes, so a non-active status on either side wins, which makes the
+# merge safe in either direction and more than once. `memories_fts` follows through its triggers;
+# a merged row is embedded the way `add` embeds (best-effort); `log` rows dedup on their own
+# (project, msg_uuid) index. The source is opened read-only and its contents are never modified
+# (reading a WAL-mode store creates empty -wal/-shm sidecars beside it, as any reader does).
+_MERGE_KEY_SQL = "project = ? AND ts = ? AND type = ? AND summary = ? AND coalesce(detail,'') = ?"
+
+
+def _open_store_readonly(path: str) -> sqlite3.Connection:
+    """Open another engrim store for reading only — no schema migration, no WAL switch, and the
+    file is never created or written. Exits with a plain message when `path` is not an engrim
+    store."""
+    if not os.path.isfile(path):
+        sys.exit(f"merge: no such file: {path}")
+    try:
+        src = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        src.row_factory = sqlite3.Row
+        has = src.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='memories'").fetchone()
+    except sqlite3.DatabaseError:
+        sys.exit(f"merge: not an engrim store (not a SQLite database): {path}")
+    if not has:
+        sys.exit(f"merge: not an engrim store (no memories table): {path}")
+    return src
+
+
+def merge_store(conn, other_path, project=None, dry_run=False):
+    """Fold OTHER's memories (and transcript log rows) into `conn`.
+
+    Returns (added, restatused, skipped, log_added, plan) where plan is a list of
+    (action, summary) for --dry-run / --verbose. Idempotent: a second run adds nothing."""
+    src = _open_store_readonly(other_path)
+    src_cols = {r[1] for r in src.execute("PRAGMA table_info(memories)")}
+    where, params = ("WHERE project = ?", (project,)) if project else ("", ())
+    rows = src.execute(f"SELECT * FROM memories {where} ORDER BY id", params).fetchall()
+    added = restatused = skipped = 0
+    plan = []
+    fn, name = _resolve_embedder()
+    for r in rows:
+        detail = r["detail"]
+        key = (r["project"], r["ts"], r["type"], r["summary"], detail or "")
+        mine = conn.execute(
+            f"SELECT id, status FROM memories WHERE {_MERGE_KEY_SQL}", key).fetchone()
+        if mine is None:
+            plan.append(("add", r["summary"]))
+            added += 1
+            if dry_run:
+                continue
+            cur = conn.execute(
+                "INSERT INTO memories(ts,project,type,summary,detail,status,tags,links,source,origin_agent) "
+                "VALUES(?,?,?,?,?,?,?,?,?,?)",
+                (r["ts"], r["project"], r["type"], r["summary"], detail, r["status"],
+                 r["tags"], r["links"], r["source"],
+                 r["origin_agent"] if "origin_agent" in src_cols else None))
+            if fn:
+                try:
+                    _embed_row(conn, cur.lastrowid, r["summary"], detail, fn, name)
+                except Exception:
+                    pass
+        elif mine["status"] == "active" and r["status"] != "active":
+            plan.append((r["status"][:4], r["summary"]))
+            restatused += 1
+            if not dry_run:
+                conn.execute("UPDATE memories SET status=? WHERE id=?", (r["status"], mine["id"]))
+        else:
+            plan.append(("skip", r["summary"]))
+            skipped += 1
+    log_added = 0
+    if src.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='log'").fetchone():
+        log_cols = {c[1] for c in src.execute("PRAGMA table_info(log)")}
+        for lr in src.execute(f"SELECT * FROM log {where} ORDER BY id", params):
+            # Rows with a uuid dedup on the store's own (project, msg_uuid) index; rows without
+            # one (NULLs never collide there) dedup on their content instead, so a second merge
+            # adds nothing either way.
+            if lr["msg_uuid"]:
+                exists = conn.execute("SELECT 1 FROM log WHERE project = ? AND msg_uuid = ?",
+                                      (lr["project"], lr["msg_uuid"])).fetchone()
+            else:
+                exists = conn.execute(
+                    "SELECT 1 FROM log WHERE project = ? AND ts = ? AND role = ? "
+                    "AND coalesce(content,'') = ? AND msg_uuid IS NULL",
+                    (lr["project"], lr["ts"], lr["role"], lr["content"] or "")).fetchone()
+            if exists:
+                continue
+            log_added += 1
+            if not dry_run:
+                conn.execute(
+                    "INSERT INTO log(ts,project,session,role,content,raw,msg_uuid) "
+                    "VALUES(?,?,?,?,?,?,?)",
+                    (lr["ts"], lr["project"], lr["session"], lr["role"], lr["content"],
+                     lr["raw"] if "raw" in log_cols else None, lr["msg_uuid"]))
+    src.close()
+    if not dry_run:
+        conn.commit()
+    return added, restatused, skipped, log_added, plan
+
+
+def cmd_merge(conn, a) -> None:
+    """Fold another store's records into this one (see merge_store). `--project` narrows to one
+    project tag; the default takes every project the other store holds, since merging is about
+    two copies of the same memory, not about which directory you happen to be in."""
+    if os.path.isfile(a.other) and os.path.realpath(a.other) == os.path.realpath(a.db):
+        sys.exit("merge: source and target are the same store")
+    added, restatused, skipped, log_added, plan = merge_store(
+        conn, a.other, project=a.project, dry_run=a.dry_run)
+    head = "DRY-RUN — no changes written" if a.dry_run else "merged"
+    print(f"{head}: +{added} add, ~{restatused} status, {skipped} skip, +{log_added} log "
+          f"-> from {a.other}")
+    if a.dry_run or a.verbose:
+        for action, summary in plan:
+            print(f"  {action:4} {summary[:80]}")
+
+
 # --------------------------------------------------------------------------- transcript log
 # A SEPARATE, append-only tier from `memories`. It records the raw back-and-forth so engineers
 # have a full, replayable record — but it is NEVER injected into the boot pack / context window, so
@@ -2691,6 +2814,14 @@ def build_parser() -> argparse.ArgumentParser:
                      help="keep records whose md source vanished (default: supersede them)")
     psy.add_argument("--verbose", action="store_true", help="list every add/update/skip/prune")
     psy.set_defaults(func=cmd_sync)
+
+    pmg = sub.add_parser("merge", help="fold another engrim store's records into this one (idempotent)")
+    pmg.add_argument("other", help="path to the other engrim store (opened read-only)")
+    pmg.add_argument("-p", "--project", default=None,
+                     help="only this project tag (default: every project in the other store)")
+    pmg.add_argument("--dry-run", action="store_true", help="show the plan, write nothing")
+    pmg.add_argument("--verbose", action="store_true", help="list every add/status/skip")
+    pmg.set_defaults(func=cmd_merge)
 
     plog = sub.add_parser("log")
     plog.add_argument("-p", "--project", default="auto")

--- a/src/engrim/cli.py
+++ b/src/engrim/cli.py
@@ -574,7 +574,9 @@ def cmd_assist(conn, a) -> None:
         if unc >= _ASSIST_CURATE_FLOOR:
             directive = (f"\n[engrim · auto-curate] {unc} decisions are logged but not yet in curated "
                          "memory. Before your next reply, SILENTLY `engrim add` the durable ones "
-                         "(skip chatter, reversed calls, and false-positives); don't announce it.")
+                         "(skip chatter, reversed calls, and false-positives); don't announce it. "
+                         "Record what was MEASURED, not what was concluded — 'momentum score is the "
+                         "constant 92.0' ages well; 'momentum looks broken' doesn't.")
     except Exception:
         directive = ""
     if not out and not directive:
@@ -711,9 +713,8 @@ def _boot_pack(rows, budget):
 # already records every turn, but the curated boot pack never read the log, so the last stretch of work
 # vanished on clear. Deliberately tiny and SEPARATE from the curated budget — a hard item cap plus its
 # own char sub-budget — so it can never crowd out curated records or bloat context. Dedup uses the
-# LEXICAL captured-check (no embedder) to keep every boot fast and model-load-free; the explicitly-run
-# `review` stays embedder-precise. Biases toward showing recent work (continuity) over hiding it.
-_TAIL_SCAN = 40            # recent log turns to scan for decision signal
+# SHARED captured-check (`_is_captured`), same as `review` and the status bar, so the three surfaces
+# can never disagree about what's already curated. Biases toward showing recent work over hiding it.
 _TAIL_MAX_ITEMS = 3        # hard cap on tail lines — recency hint, not a transcript dump
 _TAIL_BUDGET = 600         # own char sub-budget, independent of the curated boot budget
 _TAIL_SNIPPET_CAP = 180    # per-line truncation
@@ -727,10 +728,23 @@ _TAIL_SNIPPET_CAP = 180    # per-line truncation
 # window so a fresh project stays lean.
 _UNCAPTURED_MAX_SCAN = 200
 
+# ONE lean recent window for every clear-readiness surface — the status bar, the minder's auto-curate
+# nudge, the boot tail, and `review`. They used to carry their own numbers (25 vs 40 vs a flat -k),
+# so the bar could count a turn `review` never scanned and the two would report different backlogs
+# on the same db (#747). Same window + same captured-check = they agree by construction.
+_CAPTURE_SCAN = 40
+_TAIL_SCAN = _CAPTURE_SCAN
+
 # Mid-session auto-curate backstop: the boot directive only fires at the NEXT session, so a single long
 # session can accumulate uncaptured decisions. Once the backlog crosses this floor the minder nudges the
-# AGENT (not the user) to promote them. Set high enough that ordinary work-in-progress never trips it.
-_ASSIST_CURATE_FLOOR = 4
+# AGENT (not the user) to promote them.
+#
+# Floor of 2, lowered from 4 (Tim, 2026-08-11): a wrap-time-only capture habit loses exactly the
+# sessions that ran long — the ones worth keeping — because a window-close or limit-expiry can't
+# curate itself. Capture wants to happen at the MOMENT of the decision. The old floor of 4 was priced
+# for a counter that cried wolf; now that the captured-check can't false-positive on a paraphrase
+# (#747), an earlier nudge is cheap and the backlog rarely gets deep enough to lose.
+_ASSIST_CURATE_FLOOR = 2
 
 
 def _parse_ts(s):
@@ -792,7 +806,7 @@ def _recent_tail(conn, project, scan=_TAIL_SCAN, max_items=_TAIL_MAX_ITEMS, budg
         if not snip or key in seen or _looks_like_narration(snip):
             continue
         seen.add(key)
-        if _lexical_overlap_captured(conn, project, snip):     # already covered by a curated record
+        if _is_captured(conn, project, snip):     # already covered by a curated record
             continue
         if len(snip) > _TAIL_SNIPPET_CAP:
             snip = snip[:_TAIL_SNIPPET_CAP - 1].rstrip() + "…"
@@ -806,10 +820,37 @@ def _recent_tail(conn, project, scan=_TAIL_SCAN, max_items=_TAIL_MAX_ITEMS, budg
     return out
 
 
-def _uncaptured_count(conn, project, scan=25, cap=9):
-    """Cheap, model-free count of recent decision-signal log turns not yet covered by a curated record —
-    the same 'safe to clear?' signal `review` reports, kept light enough for the ambient status bar (a
-    small bounded log scan + lexical capture-check, no embedder). Powers the live 'N to capture' nudge."""
+def _uncaptured_state_key(conn, project):
+    """Fingerprint of everything `_uncaptured_count` reads: the newest logged turn, the newest curated
+    record, and how many records are active (so a `supersede` invalidates too). Plus the embed mode,
+    since that changes which tier of the captured-check can run."""
+    row = conn.execute(
+        "SELECT (SELECT MAX(ts) FROM log WHERE project=?),"
+        "       (SELECT MAX(ts) FROM memories WHERE project=? AND status='active'),"
+        "       (SELECT COUNT(*) FROM memories WHERE project=? AND status='active')",
+        (project, project, project)).fetchone()
+    mode = os.environ.get("ENGRIM_EMBED", "").strip().lower()
+    return f"{row[0]}|{row[1]}|{row[2]}|{mode}"
+
+
+def _uncaptured_count(conn, project, scan=_CAPTURE_SCAN, cap=9):
+    """Count of recent decision-signal log turns not yet covered by a curated record — the live
+    "safe to clear?" signal behind the status bar's `✎ N to capture` and the minder's auto-curate
+    nudge. Shares BOTH the scan window (`_CAPTURE_SCAN`) and the captured-check (`_is_captured`) with
+    `review`, so the ambient number and the explicit command can't contradict each other (#747).
+
+    Kept cheap two ways: the lexical tier resolves most snippets with no model at all, and the result
+    is memoized against a fingerprint of the rows it read — so the status bar, which re-runs on every
+    refresh, recomputes only when the log or the store actually changed."""
+    try:
+        state = _uncaptured_state_key(conn, project)
+        cached = _meta_get(conn, project, "unc_cache")
+        if cached:
+            ckey, _, cval = cached.partition("=")
+            if ckey == state and cval.isdigit():
+                return int(cval)
+    except Exception:
+        state = None
     try:
         floor = _capture_floor(conn, project)
         rows = conn.execute("SELECT ts, content FROM log WHERE project=? ORDER BY ts DESC LIMIT ?",
@@ -828,11 +869,16 @@ def _uncaptured_count(conn, project, scan=25, cap=9):
         if not snip or key in seen or _looks_like_narration(snip):
             continue
         seen.add(key)
-        if _lexical_overlap_captured(conn, project, snip):
+        if _is_captured(conn, project, snip):
             continue
         n += 1
         if n >= cap:
             break
+    if state:
+        try:
+            _meta_set(conn, project, "unc_cache", f"{state}={n}")
+        except Exception:
+            pass                                 # a read-only db must never break the status bar
     return n
 
 
@@ -904,6 +950,8 @@ def cmd_context(conn, a) -> None:
                       "engrim add -t <decision|fact|state|feedback> -s \"<one line>\" [-d \"<why>\"]")
                 print("  Skip chatter, reversed calls, and product copy (known false-positives) — keep the "
                       "store high-signal. Don't announce this; just curate, then proceed.")
+                print("  Write what was MEASURED, not what was concluded: 'momentum score is the constant "
+                      "92.0' stays true and useful; 'momentum looks broken' rots into a dead end.")
         elif unc:
             print(f"\n✎ {unc} recent decision(s) not yet curated — worth capturing before your next "
                   "/clear:  engrim add -t decision -s \"…\"")
@@ -1659,9 +1707,36 @@ def _max_similarity(conn, project, text, fn):
     return max(_cosine(qv, _blob_vec(r["vec"])) for r in rows)
 
 
+_UNSET = object()   # "caller didn't supply an embedder" — distinct from an explicit None ("lexical only")
+
+
+def _is_captured(conn, project, snippet, fn=_UNSET):
+    """THE definition of "this decision is already in curated memory". Every clear-readiness surface
+    (status bar, minder nudge, boot tail, `review`) must route through here — they used to each pick
+    their own check, and on a host WITH an embedder that split into two different answers: `review`
+    scored a paraphrase as captured (cosine >= _CAPTURED_SIM) while the bar, hard-wired to the lexical
+    check, kept counting it forever. Curating a decision in your own words then never cleared the
+    nudge, so the counter looked stale and cried wolf — the exact trust the clear-safe signal is for
+    (#219, #747).
+
+    Evidence is a UNION: strong word overlap OR semantic match. Both are evidence of the same thing,
+    and taking either keeps the answer stable when the embedder is unavailable on one call and present
+    on the next (a lexical hit stays a hit either way).
+
+    Tiered on purpose: the lexical pass is free and runs first, so a project that's already clear-safe
+    never pays for a model load. Only a snippet that lexical would NAG about escalates to the embedder
+    — cost lands exactly where it buys precision. Pass `fn` if you've already resolved an embedder;
+    pass None to force pure-lexical."""
+    if _lexical_overlap_captured(conn, project, snippet):
+        return True
+    if fn is _UNSET:                    # not supplied -> resolve lazily (cached per process)
+        fn, _ = _resolve_embedder()
+    return bool(fn) and _max_similarity(conn, project, snippet, fn) >= _CAPTURED_SIM
+
+
 def _lexical_overlap_captured(conn, project, snippet):
-    """Lexical fallback for the captured-check (used only when there's no embedding backend): does any
-    active record share most of the snippet's content words? Conservative on purpose."""
+    """Lexical tier of the captured-check (see `_is_captured`): does any active record share most of
+    the snippet's content words? Conservative on purpose."""
     toks = set(re.findall(r"[a-z0-9]{4,}", snippet.lower()))
     if not toks:
         return False
@@ -1688,9 +1763,19 @@ def cmd_review(conn, a) -> None:
         print("  no transcript log yet — nothing to check. "
               "(the Stop hook captures turns as you work, then `review` can vet them.)")
         return
-    rows = conn.execute(
+    # Same hybrid window the automatic surfaces use: the lean recent `-k` turns, extended back to the
+    # last capture so a decision buried under a long verification tail is still in scope. A flat
+    # last-k window here was half of why the status bar and `review` disagreed — the bar could count a
+    # turn `review` never looked at (#747).
+    floor = _capture_floor(conn, project)
+    scanned = conn.execute(
         "SELECT ts, content FROM log WHERE project = ? ORDER BY ts DESC LIMIT ?",
-        (project, a.k)).fetchall()
+        (project, max(a.k, _UNCAPTURED_MAX_SCAN))).fetchall()
+    rows = []
+    for i, r in enumerate(scanned):
+        if _past_floor(r, floor, i, a.k):
+            break
+        rows.append(r)
     print(f"  log: {total_log} turns (scanned last {len(rows)}) · curated: {curated} active records")
 
     # Resolve the embedder up front: it raises candidate RECALL (cue-less real decisions, #200) and
@@ -1719,11 +1804,9 @@ def cmd_review(conn, a) -> None:
               "(heuristic, not proof: eyeball anything you know was important.)")
         return
 
-    uncaptured = [
-        (ts, snip) for ts, snip in candidates
-        if not ((_max_similarity(conn, project, snip, fn) >= _CAPTURED_SIM) if fn
-                else _lexical_overlap_captured(conn, project, snip))
-    ]
+    # Shared captured-check — `fn` is passed explicitly (possibly None) so review uses exactly the
+    # embedder it resolved above, and the bar's lazy resolution can't diverge from it.
+    uncaptured = [(ts, snip) for ts, snip in candidates if not _is_captured(conn, project, snip, fn)]
     print(f"  {len(candidates)} decision-signal turn(s) detected; "
           f"{len(candidates) - len(uncaptured)} look captured, {len(uncaptured)} may not be.")
     if not uncaptured:
@@ -1895,7 +1978,9 @@ def build_parser() -> argparse.ArgumentParser:
 
     prv = sub.add_parser("review")
     prv.add_argument("-p", "--project", default="auto")
-    prv.add_argument("-k", type=int, default=40, help="how many recent log turns to scan (default 40)")
+    prv.add_argument("-k", type=int, default=_CAPTURE_SCAN,
+                     help=f"lean recent window of log turns to scan (default {_CAPTURE_SCAN}); the scan "
+                          "always extends back to the last capture on top of this")
     prv.set_defaults(func=cmd_review)
 
     sub.add_parser("projects").set_defaults(func=cmd_projects)

--- a/src/engrim/mcp_server.py
+++ b/src/engrim/mcp_server.py
@@ -1,0 +1,191 @@
+"""Zero-dependency MCP (Model Context Protocol) server for engrim.
+
+Exposes engrim's project memory to any MCP client (Claude Code, etc.) over the MCP
+stdio transport — newline-delimited JSON-RPC 2.0 — with no dependency beyond engrim's
+zero-dep core. Launched via `engrim mcp`. Each tool reuses the exact recall / boot-pack
+/ write logic the CLI uses, so memory behaves identically however it's reached.
+
+Tools:
+  engrim_recall   hybrid keyword+semantic search over the project's records
+  engrim_context  the session-boot memory pack (curated, budgeted)
+  engrim_add      write a durable record (decision/fact/feedback/state/user/reference)
+
+stdout carries only JSON-RPC frames (the protocol channel); anything diagnostic must
+go to stderr, which MCP clients treat as logging.
+"""
+from __future__ import annotations
+
+import json
+import sys
+
+from engrim import __version__
+from engrim.cli import (
+    TYPES, GLOBAL_PROJECT, add_memory, _resolve_project,
+    _minder_rows, _recall_rows, _boot_pack, _scopes, _in_clause,
+)
+
+# Echoed back to the client when it doesn't pin one; clients negotiate their own.
+DEFAULT_PROTOCOL_VERSION = "2024-11-05"
+
+TOOLS = [
+    {
+        "name": "engrim_recall",
+        "description": ("Search this project's engrim memory for records relevant to a query "
+                        "(hybrid keyword + semantic ranking). Use before non-trivial work to "
+                        "recall prior decisions, facts, feedback, and state."),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Free-text topic to search for."},
+                "project": {"type": "string", "default": "auto",
+                            "description": "Project tag; 'auto' = current working directory."},
+                "k": {"type": "integer", "default": 5, "description": "Max records to return."},
+                "type": {"type": "string", "enum": list(TYPES),
+                         "description": "Optional: restrict to one record type."},
+                "include_stale": {"type": "boolean", "default": False,
+                                  "description": "Include superseded/archived records."},
+            },
+            "required": ["query"],
+        },
+    },
+    {
+        "name": "engrim_context",
+        "description": ("Return the project's session-boot memory pack — the curated, high-signal "
+                        "records that orient you at the start of work, within a character budget."),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "project": {"type": "string", "default": "auto"},
+                "budget": {"type": "integer", "default": 4000,
+                           "description": "Character budget for the pack."},
+            },
+        },
+    },
+    {
+        "name": "engrim_add",
+        "description": ("Write a durable memory record so it persists across sessions. Use at real "
+                        "decision points and for durable facts/feedback/state."),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "type": {"type": "string", "enum": list(TYPES)},
+                "summary": {"type": "string", "description": "One-line headline for the record."},
+                "detail": {"type": "string", "description": "Optional longer body / the why."},
+                "tags": {"type": "array", "items": {"type": "string"}},
+                "project": {"type": "string", "default": "auto"},
+                "global": {"type": "boolean", "default": False,
+                           "description": "Write to the global user-layer that loads in every project."},
+            },
+            "required": ["type", "summary"],
+        },
+    },
+]
+
+
+def _tool_recall(conn, args: dict) -> str:
+    project = _resolve_project(args.get("project", "auto"))
+    query = args.get("query") or ""
+    k = max(0, int(args.get("k", 5)))
+    type_ = args.get("type")
+    include_stale = bool(args.get("include_stale", False))
+    if query and not type_ and not include_stale:
+        rows = _minder_rows(conn, project, query, query, k)
+    else:
+        rows = _recall_rows(conn, project, query, k, type_, include_stale)
+    recs = [{kk: vv for kk, vv in dict(r).items() if kk not in ("rank", "_vec")} for r in rows]
+    return json.dumps({"project": project, "count": len(recs), "records": recs},
+                      default=str, indent=2)
+
+
+def _tool_context(conn, args: dict) -> str:
+    project = _resolve_project(args.get("project", "auto"))
+    budget = max(0, int(args.get("budget", 4000)))
+    pclause, pparams = _in_clause(_scopes(project), "project")
+    rows = conn.execute("SELECT * FROM memories WHERE " + pclause + " AND status = 'active'",
+                        pparams).fetchall()
+    picked, used = _boot_pack(rows, budget)
+    recs = [dict(r) for r, _s in picked]
+    return json.dumps({"project": project, "loaded": len(recs), "total_active": len(rows),
+                       "chars": used, "records": recs}, default=str, indent=2)
+
+
+def _tool_add(conn, args: dict) -> str:
+    type_ = args.get("type")
+    summary = (args.get("summary") or "").strip()
+    if type_ not in TYPES:
+        raise ValueError(f"type must be one of {list(TYPES)}")
+    if not summary:
+        raise ValueError("summary cannot be empty")
+    project = GLOBAL_PROJECT if args.get("global") else _resolve_project(args.get("project", "auto"))
+    tags = args.get("tags") or []
+    if isinstance(tags, str):
+        tags = [t.strip() for t in tags.split(",") if t.strip()]
+    new_id = add_memory(conn, project=project, type=type_, summary=summary,
+                        detail=args.get("detail"), tags=list(tags))
+    return json.dumps({"id": new_id, "type": type_, "project": project, "summary": summary})
+
+
+_DISPATCH = {
+    "engrim_recall": _tool_recall,
+    "engrim_context": _tool_context,
+    "engrim_add": _tool_add,
+}
+
+
+def serve(conn, inp=None, out=None) -> None:
+    """Run the JSON-RPC stdio loop until stdin EOF. `inp`/`out` are injectable for tests."""
+    inp = inp or sys.stdin
+    out = out or sys.stdout
+
+    def _send(msg: dict) -> None:
+        out.write(json.dumps(msg) + "\n")
+        out.flush()
+
+    def _ok(rid, result) -> None:
+        _send({"jsonrpc": "2.0", "id": rid, "result": result})
+
+    def _err(rid, code, message) -> None:
+        _send({"jsonrpc": "2.0", "id": rid, "error": {"code": code, "message": message}})
+
+    while True:
+        line = inp.readline()
+        if not line:                       # EOF — client closed the transport
+            break
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue                       # ignore non-JSON noise; can't reply without an id
+        method = msg.get("method")
+        rid = msg.get("id")                # absent on notifications
+
+        if method == "initialize":
+            client_ver = (msg.get("params") or {}).get("protocolVersion") or DEFAULT_PROTOCOL_VERSION
+            _ok(rid, {
+                "protocolVersion": client_ver,
+                "capabilities": {"tools": {"listChanged": False}},
+                "serverInfo": {"name": "engrim", "version": __version__},
+            })
+        elif method == "notifications/initialized":
+            continue                       # notification: no response
+        elif method == "ping":
+            _ok(rid, {})
+        elif method == "tools/list":
+            _ok(rid, {"tools": TOOLS})
+        elif method == "tools/call":
+            params = msg.get("params") or {}
+            name = params.get("name")
+            fn = _DISPATCH.get(name)
+            if fn is None:
+                _err(rid, -32602, f"unknown tool: {name}")
+                continue
+            try:
+                text = fn(conn, params.get("arguments") or {})
+                _ok(rid, {"content": [{"type": "text", "text": text}], "isError": False})
+            except Exception as e:         # tool errors are reported in-band, never crash the server
+                _ok(rid, {"content": [{"type": "text", "text": f"error: {e}"}], "isError": True})
+        elif rid is not None:
+            _err(rid, -32601, f"method not found: {method}")
+        # else: unknown notification — ignore

--- a/src/engrim/mcp_server.py
+++ b/src/engrim/mcp_server.py
@@ -1,14 +1,16 @@
 """Zero-dependency MCP (Model Context Protocol) server for engrim.
 
-Exposes engrim's project memory to any MCP client (Claude Code, etc.) over the MCP
-stdio transport — newline-delimited JSON-RPC 2.0 — with no dependency beyond engrim's
-zero-dep core. Launched via `engrim mcp`. Each tool reuses the exact recall / boot-pack
-/ write logic the CLI uses, so memory behaves identically however it's reached.
+Exposes engrim's project memory to any MCP client (Antigravity, Cursor, Claude Code, etc.)
+over the MCP stdio transport — newline-delimited JSON-RPC 2.0 — with no dependency beyond
+engrim's core. Launched via `engrim serve --mcp` (or `engrim mcp`). Each tool reuses the
+exact recall / boot-pack / write logic the CLI uses, so memory behaves identically
+however it's reached.
 
 Tools:
   engrim_recall   hybrid keyword+semantic search over the project's records
   engrim_context  the session-boot memory pack (curated, budgeted)
   engrim_add      write a durable record (decision/fact/feedback/state/user/reference)
+  engrim_review   check uncaptured decisions before clearing context
 
 stdout carries only JSON-RPC frames (the protocol channel); anything diagnostic must
 go to stderr, which MCP clients treat as logging.
@@ -20,8 +22,11 @@ import sys
 
 from engrim import __version__
 from engrim.cli import (
-    TYPES, GLOBAL_PROJECT, add_memory, _resolve_project,
+    TYPES, GLOBAL_PROJECT, ORIGIN_AGENTS, add_memory, _resolve_project,
     _minder_rows, _recall_rows, _boot_pack, _scopes, _in_clause,
+    _capture_floor, _past_floor, _decision_snippet, _looks_like_narration,
+    _semantic_decision_snippet, _is_captured, _resolve_embedder,
+    _DECISION_CUES, _DECISION_EXEMPLARS, _UNCAPTURED_MAX_SCAN,
 )
 
 # Echoed back to the client when it doesn't pin one; clients negotiate their own.
@@ -75,8 +80,25 @@ TOOLS = [
                 "project": {"type": "string", "default": "auto"},
                 "global": {"type": "boolean", "default": False,
                            "description": "Write to the global user-layer that loads in every project."},
+                "origin_agent": {
+                    "type": "string",
+                    "enum": list(ORIGIN_AGENTS),
+                    "description": "Origin agent identifier for provenance tracking.",
+                },
             },
             "required": ["type", "summary"],
+        },
+    },
+    {
+        "name": "engrim_review",
+        "description": ("Check coverage before clearing context: surface recent decisions from "
+                        "the transcript log that don't appear to be in curated memory yet."),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "project": {"type": "string", "default": "auto",
+                            "description": "Project tag; 'auto' = current working directory."},
+            },
         },
     },
 ]
@@ -109,7 +131,7 @@ def _tool_context(conn, args: dict) -> str:
                        "chars": used, "records": recs}, default=str, indent=2)
 
 
-def _tool_add(conn, args: dict) -> str:
+def _tool_add(conn, args: dict, client_agent: str | None = None) -> str:
     type_ = args.get("type")
     summary = (args.get("summary") or "").strip()
     if type_ not in TYPES:
@@ -120,15 +142,87 @@ def _tool_add(conn, args: dict) -> str:
     tags = args.get("tags") or []
     if isinstance(tags, str):
         tags = [t.strip() for t in tags.split(",") if t.strip()]
+    origin_agent = args.get("origin_agent") or client_agent or "cursor"
     new_id = add_memory(conn, project=project, type=type_, summary=summary,
-                        detail=args.get("detail"), tags=list(tags))
-    return json.dumps({"id": new_id, "type": type_, "project": project, "summary": summary})
+                        detail=args.get("detail"), tags=list(tags),
+                        origin_agent=origin_agent)
+    return json.dumps({
+        "id": new_id,
+        "type": type_,
+        "project": project,
+        "summary": summary,
+        "origin_agent": origin_agent,
+    })
+
+
+def _tool_review(conn, args: dict) -> str:
+    project = _resolve_project(args.get("project", "auto"))
+    total_log = conn.execute("SELECT COUNT(*) FROM log WHERE project = ?", (project,)).fetchone()[0]
+    curated = conn.execute("SELECT COUNT(*) FROM memories WHERE project = ? AND status = 'active'",
+                           (project,)).fetchone()[0]
+    if not total_log:
+        return json.dumps({
+            "project": project,
+            "total_log_turns": 0,
+            "active_curated": curated,
+            "safe_to_clear": True,
+            "uncaptured": [],
+            "message": "no transcript log yet — nothing to check.",
+        }, indent=2)
+
+    floor = _capture_floor(conn, project)
+    scanned = conn.execute(
+        "SELECT ts, content FROM log WHERE project = ? ORDER BY ts DESC LIMIT ?",
+        (project, _UNCAPTURED_MAX_SCAN)).fetchall()
+    rows = []
+    for i, r in enumerate(scanned):
+        if _past_floor(r, floor, i, 40):
+            break
+        rows.append(r)
+
+    fn, _name = _resolve_embedder()
+    exemplar_vecs = [fn(e) for e in _DECISION_EXEMPLARS] if fn else []
+
+    seen, candidates = set(), []
+    for r in rows:
+        snip = None
+        if any(cue in (r["content"] or "").lower() for cue in _DECISION_CUES):
+            snip = _decision_snippet(r["content"])
+            if _looks_like_narration(snip):
+                snip = None
+        if snip is None and fn:
+            snip = _semantic_decision_snippet(r["content"], fn, exemplar_vecs)
+        if not snip:
+            continue
+        key = snip.lower()[:80]
+        if key in seen:
+            continue
+        seen.add(key)
+        candidates.append((r["ts"], snip))
+
+    uncaptured = [
+        {"timestamp": ts, "summary": snip}
+        for ts, snip in candidates
+        if not _is_captured(conn, project, snip, fn)
+    ]
+
+    return json.dumps({
+        "project": project,
+        "total_log_turns": total_log,
+        "scanned_turns": len(rows),
+        "active_curated": curated,
+        "safe_to_clear": len(uncaptured) == 0,
+        "uncaptured_count": len(uncaptured),
+        "uncaptured": uncaptured,
+        "message": "recent decisions appear captured — safe to clear." if not uncaptured else f"{len(uncaptured)} uncaptured decision(s) detected — capture before clearing",
+    }, indent=2)
 
 
 _DISPATCH = {
     "engrim_recall": _tool_recall,
     "engrim_context": _tool_context,
     "engrim_add": _tool_add,
+    "engrim_review": _tool_review,
 }
 
 
@@ -136,6 +230,7 @@ def serve(conn, inp=None, out=None) -> None:
     """Run the JSON-RPC stdio loop until stdin EOF. `inp`/`out` are injectable for tests."""
     inp = inp or sys.stdin
     out = out or sys.stdout
+    detected_client: str | None = None
 
     def _send(msg: dict) -> None:
         out.write(json.dumps(msg) + "\n")
@@ -162,6 +257,15 @@ def serve(conn, inp=None, out=None) -> None:
         rid = msg.get("id")                # absent on notifications
 
         if method == "initialize":
+            client_info = (msg.get("params") or {}).get("clientInfo", {})
+            cname = client_info.get("name", "").lower()
+            if "antigravity" in cname or "gemini" in cname:
+                detected_client = "antigravity"
+            elif "claude" in cname:
+                detected_client = "claude-code"
+            elif "cursor" in cname:
+                detected_client = "cursor"
+
             client_ver = (msg.get("params") or {}).get("protocolVersion") or DEFAULT_PROTOCOL_VERSION
             _ok(rid, {
                 "protocolVersion": client_ver,
@@ -182,7 +286,10 @@ def serve(conn, inp=None, out=None) -> None:
                 _err(rid, -32602, f"unknown tool: {name}")
                 continue
             try:
-                text = fn(conn, params.get("arguments") or {})
+                if name == "engrim_add":
+                    text = _tool_add(conn, params.get("arguments") or {}, client_agent=detected_client)
+                else:
+                    text = fn(conn, params.get("arguments") or {})
                 _ok(rid, {"content": [{"type": "text", "text": text}], "isError": False})
             except Exception as e:         # tool errors are reported in-band, never crash the server
                 _ok(rid, {"content": [{"type": "text", "text": f"error: {e}"}], "isError": True})

--- a/tests/test_agy_adapter.py
+++ b/tests/test_agy_adapter.py
@@ -1,0 +1,95 @@
+"""Tests for the Antigravity (AGY) Lifecycle Hook Adapter."""
+import io
+import json
+import sqlite3
+import pytest
+
+from engrim.adapters.agy import handle_boot, handle_stop, get_project_path
+from engrim.cli import connect, main, add_memory
+
+
+def test_get_project_path_resolution():
+    # Priority: workspacePaths[0] > cwd > os.getcwd()
+    assert get_project_path({"workspacePaths": ["/custom/workspace"], "cwd": "/fallback"}) == "/custom/workspace"
+    assert get_project_path({"workspacePaths": [], "cwd": "/fallback"}) == "/fallback"
+    assert get_project_path({}) != ""
+
+
+def test_handle_boot_inject_steps_structure(tmp_path):
+    db = str(tmp_path / "m.db")
+    conn = connect(db)
+    add_memory(
+        conn,
+        project="/test/proj",
+        type="decision",
+        summary="Use inverted stop loss matrix for high volatility",
+        origin_agent="antigravity",
+    )
+    conn.close()
+
+    mock_payload = {
+        "workspacePaths": ["/test/proj"],
+        "cwd": "/test/proj",
+    }
+
+    res = handle_boot(mock_payload, db_path=db, print_output=False)
+    assert "injectSteps" in res
+    assert isinstance(res["injectSteps"], list)
+    assert len(res["injectSteps"]) == 1
+    assert "ephemeralMessage" in res["injectSteps"][0]
+    msg = res["injectSteps"][0]["ephemeralMessage"]
+    assert "inverted stop loss matrix" in msg.lower()
+    assert "(via Antigravity)" in msg
+
+
+def test_handle_stop_ingests_transcript(tmp_path):
+    db = str(tmp_path / "m.db")
+    transcript_file = tmp_path / "transcript.jsonl"
+    transcript_lines = [
+        {"step_index": 0, "source": "USER_EXPLICIT", "type": "USER_INPUT", "content": "Let's change risk params"},
+        {"step_index": 1, "source": "MODEL", "type": "PLANNER_RESPONSE", "content": "I have updated the parameters to 2.5%"},
+    ]
+    with open(transcript_file, "w", encoding="utf-8") as f:
+        for line in transcript_lines:
+            f.write(json.dumps(line) + "\n")
+
+    mock_payload = {
+        "workspacePaths": ["/test/proj"],
+        "transcriptPath": str(transcript_file),
+        "conversationId": "conv-1234",
+    }
+
+    res = handle_stop(mock_payload, db_path=db, print_output=False)
+    assert res == {}
+
+    conn = connect(db)
+    rows = conn.execute("SELECT role, content FROM log WHERE project='/test/proj'").fetchall()
+    assert len(rows) == 2
+    assert rows[0]["role"] == "user"
+    assert "risk params" in rows[0]["content"]
+    assert rows[1]["role"] == "assistant"
+    assert "2.5%" in rows[1]["content"]
+    conn.close()
+
+
+def test_cli_hook_agy_boot_and_stop(tmp_path, monkeypatch, capsys):
+    db = str(tmp_path / "m.db")
+    conn = connect(db)
+    add_memory(conn, project="/test/proj", type="fact", summary="Host is Linux x86_64", origin_agent="antigravity")
+    conn.close()
+
+    # Test boot via CLI
+    stdin_data = json.dumps({"workspacePaths": ["/test/proj"]})
+    monkeypatch.setattr("sys.stdin", io.StringIO(stdin_data))
+    main(["--db", db, "hook", "--agent", "agy", "--event", "boot"])
+    out = capsys.readouterr().out
+    boot_json = json.loads(out)
+    assert "injectSteps" in boot_json
+    assert "Host is Linux x86_64" in boot_json["injectSteps"][0]["ephemeralMessage"]
+
+    # Test stop via CLI
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"workspacePaths": ["/test/proj"]})))
+    main(["--db", db, "hook", "--agent", "agy", "--event", "stop"])
+    out = capsys.readouterr().out
+    stop_json = json.loads(out)
+    assert stop_json == {}

--- a/tests/test_cross_platform.py
+++ b/tests/test_cross_platform.py
@@ -1,0 +1,181 @@
+"""Cross-platform regression tests — the failures a Linux/macOS dev never sees.
+
+Every case here was a real Windows bug found on a fresh install, and every one of them was SILENT:
+setup printed green checkmarks while wiring hooks that could not run, and the piped commands that
+crashed looked perfect in a terminal. They're pinned here because the whole class is invisible on
+the platform this is developed on.
+"""
+import io
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+import engrim.cli as cli
+from engrim.cli import main
+
+WIN_BIN = r"C:\Users\timgo\AppData\Local\Programs\Python\Python313\Scripts\engrim.EXE"
+
+
+def _run_setup(tmp_path, monkeypatch, which=WIN_BIN):
+    """Run `setup` against a throwaway settings.json with the resolved binary path faked."""
+    monkeypatch.setattr(cli.shutil, "which", lambda _n: which)
+    settings = tmp_path / "settings.json"
+    main(["--db", str(tmp_path / "m.db"), "setup", "--settings", str(settings), "--no-claude-md"])
+    return settings, json.loads(settings.read_text(encoding="utf-8"))
+
+
+def _commands(cfg):
+    return [h["command"] for groups in cfg["hooks"].values() for g in groups for h in g["hooks"]]
+
+
+# --------------------------------------------------------------------- 1. the unquoted Windows path
+
+def test_setup_writes_hook_paths_the_shell_can_actually_run(tmp_path, monkeypatch):
+    """Raw, `C:\\Users\\...` reaches bash as `C:UserstimgoAppData...` — backslashes eaten as escape
+    sequences, command not found, and `2>/dev/null || true` swallows the error. Silent no-op."""
+    _, cfg = _run_setup(tmp_path, monkeypatch)
+    cmds = _commands(cfg) + [cfg["statusLine"]["command"]]
+    assert cmds, "setup wired nothing"
+    for cmd in cmds:
+        assert "\\" not in cmd, f"backslash survives into a shell command: {cmd}"
+        assert cmd.startswith('"') and '" ' in cmd, f"binary path is not quoted: {cmd}"
+        assert "engrim.EXE" in cmd                      # the real binary, not a bare guess
+
+
+def test_setup_quotes_posix_paths_with_spaces(tmp_path, monkeypatch):
+    """Same quoting bug, rarer trigger: a space in the install path split the command in two."""
+    _, cfg = _run_setup(tmp_path, monkeypatch, which="/opt/my tools/bin/engrim")
+    assert all('"/opt/my tools/bin/engrim"' in c for c in _commands(cfg))
+
+
+# ------------------------------------------------------------------------- 2. idempotency of setup
+
+def test_setup_does_not_duplicate_hooks_on_windows(tmp_path, monkeypatch):
+    """setup is documented idempotent. The marker `engrim hook` never matched `engrim.EXE hook`,
+    so on Windows every run appended another hook group — four more on every invocation."""
+    _, first = _run_setup(tmp_path, monkeypatch)
+    _, second = _run_setup(tmp_path, monkeypatch)
+    for event in first["hooks"]:
+        assert len(second["hooks"][event]) == 1, f"{event} duplicated on the second run"
+    assert second["hooks"] == first["hooks"]
+    assert second["statusLine"] == first["statusLine"]
+
+
+def test_setup_recognises_hooks_written_before_the_quoting_fix(tmp_path, monkeypatch):
+    """The upgrade path: an existing install has unquoted POSIX commands. Re-running setup must
+    still see its own hooks and leave them alone rather than wiring a second copy."""
+    settings = tmp_path / "settings.json"
+    settings.write_text(json.dumps({"hooks": {
+        "SessionStart": [{"hooks": [{"type": "command",
+                                     "command": "/usr/local/bin/engrim hook 2>/dev/null || true"}]}],
+    }}), encoding="utf-8")
+    monkeypatch.setattr(cli.shutil, "which", lambda _n: "/usr/local/bin/engrim")
+    main(["--db", str(tmp_path / "m.db"), "setup", "--settings", str(settings), "--no-claude-md"])
+    cfg = json.loads(settings.read_text(encoding="utf-8"))
+    assert len(cfg["hooks"]["SessionStart"]) == 1
+
+
+def test_setup_leaves_an_existing_engrim_status_line_alone(tmp_path, monkeypatch):
+    """Same normalisation, applied to the status line — a Windows-spelled one must be recognised."""
+    settings = tmp_path / "settings.json"
+    settings.write_text(json.dumps(
+        {"statusLine": {"type": "command", "command": f'"{WIN_BIN}" statusline'}}), encoding="utf-8")
+    monkeypatch.setattr(cli.shutil, "which", lambda _n: WIN_BIN)
+    main(["--db", str(tmp_path / "m.db"), "setup", "--settings", str(settings), "--no-claude-md"])
+    cfg = json.loads(settings.read_text(encoding="utf-8"))
+    assert cfg["statusLine"]["command"] == f'"{WIN_BIN}" statusline'   # untouched, not re-wired
+
+
+# ------------------------------------------------------- 3. the std streams are not always UTF-8
+
+def _swap_stdout_to(monkeypatch, encoding):
+    """Stand in for a Windows pipe: a text stream over bytes with a non-UTF-8 codec."""
+    raw = io.BytesIO()
+    monkeypatch.setattr(cli.sys, "stdout", io.TextIOWrapper(raw, encoding=encoding, newline=""))
+    return raw
+
+
+def test_statusline_survives_a_cp1252_stdout(tmp_path, monkeypatch):
+    """Windows gives a piped stdout cp1252, and Claude Code reads the status line through a pipe.
+    The bar leads with 🧠, so it died with UnicodeEncodeError on every single refresh."""
+    db = tmp_path / "m.db"
+    main(["--db", str(db), "add", "-p", "/p", "-t", "fact", "-s", "a curated record"])
+    raw = _swap_stdout_to(monkeypatch, "cp1252")
+    main(["--db", str(db), "statusline", "-p", "/p"])          # used to raise UnicodeEncodeError
+    cli.sys.stdout.flush()
+    assert "🧠 engrim" in raw.getvalue().decode("utf-8")
+
+
+@pytest.mark.parametrize("cmd", ["context", "stats"])
+def test_other_emoji_commands_survive_a_cp1252_stdout(tmp_path, monkeypatch, cmd):
+    db = tmp_path / "m.db"
+    main(["--db", str(db), "add", "-p", "/p", "-t", "fact", "-s", "a curated record"])
+    raw = _swap_stdout_to(monkeypatch, "cp1252")
+    main(["--db", str(db), cmd, "-p", "/p"])
+    cli.sys.stdout.flush()
+    assert raw.getvalue()                                       # produced output instead of dying
+
+
+def test_hook_payload_decodes_when_stdin_is_not_utf8(tmp_path, monkeypatch):
+    """The mirror image: stdin is cp1252 too, while Claude Code sends UTF-8 JSON. `assist` catches
+    the decode failure and emits an empty block, so the minder just silently injected nothing.
+
+    The Cyrillic capital is deliberate: it encodes to D0 90, and 0x90 is one of the few bytes cp1252
+    genuinely refuses. Most UTF-8 sneaks through that codec as mojibake instead — quieter, and it
+    corrupts the prompt the ranking runs on, which is why the encoding is asserted directly too."""
+    db = tmp_path / "m.db"
+    main(["--db", str(db), "add", "-p", "/p", "-t", "fact",
+          "-s", "the billing pipeline reconciles nightly"])
+    payload = json.dumps({"prompt": "how does the billing pipeline treat Алиса's café résumé 🧠",
+                          "workspace": {"project_dir": "/p"}}).encode("utf-8")
+    monkeypatch.setattr(cli.sys, "stdin",
+                        io.TextIOWrapper(io.BytesIO(payload), encoding="cp1252"))
+    raw = _swap_stdout_to(monkeypatch, "cp1252")
+    main(["--db", str(db), "assist", "-p", "/p"])
+    cli.sys.stdout.flush()
+    out = json.loads(raw.getvalue().decode("utf-8"))
+    assert "billing pipeline" in out["hookSpecificOutput"]["additionalContext"]
+    assert (cli.sys.stdin.encoding or "").lower().replace("-", "") == "utf8"
+
+
+def test_no_text_file_is_opened_with_the_locale_codec():
+    """Guard the whole class: `open()` defaults to cp1252 on Windows, so every text read/write has
+    to name its encoding. Reading a settings.json or CLAUDE.md containing an emoji crashed setup."""
+    src = Path(cli.__file__).parent
+    offenders = []
+    for path in sorted(src.glob("*.py")):
+        for n, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if re.search(r"(?<![\w.])open\(", line) and "encoding=" not in line \
+                    and not re.search(r"""["'][rwax]b["']""", line):
+                offenders.append(f"{path.name}:{n}: {line.strip()}")
+    assert not offenders, "text-mode open() without encoding=:\n" + "\n".join(offenders)
+
+
+# ------------------------------------------------------------- project tags must not split in two
+
+def test_windows_project_tags_converge_on_one_spelling(monkeypatch):
+    """The tag is a dict key into your memory. The same directory arrives as `C:\\p` from getcwd()
+    and `c:/p` from a hook payload; ungrouped, that is two memories for one project."""
+    monkeypatch.setattr(cli.os, "name", "nt")
+    assert cli._norm_project(r"c:/Users/Tim/proj") == cli._norm_project(r"C:\Users\Tim\proj")
+    assert cli._norm_project(r"c:\Users\Tim\proj\.") == cli._norm_project(r"C:\Users\Tim\proj")
+    assert cli._norm_project(r"c:\Users\Tim\proj").startswith("C:")   # drive normalised, case kept
+    assert "Users" in cli._norm_project(r"c:\Users\Tim\proj")
+
+
+def test_posix_project_tags_are_untouched(monkeypatch):
+    """POSIX paths are already the one true spelling — normalising there would silently re-tag
+    every existing record in every store in the wild."""
+    monkeypatch.setattr(cli.os, "name", "posix")
+    for p in ("/home/tim/engrim", "/home/tim/engrim/.", "/Home/Tim/Engrim"):
+        assert cli._norm_project(p) == p
+
+
+def test_explicit_project_tags_are_never_rewritten(tmp_path, monkeypatch):
+    """`-p my-tag` is a user-chosen label, not a path — normalisation must not touch it."""
+    monkeypatch.setattr(cli.os, "name", "nt")
+    assert cli._resolve_project("My-Tag") == "My-Tag"
+    monkeypatch.setenv("ENGRIM_PROJECT", "Team/Shared")
+    assert cli._resolve_project("auto") == "Team/Shared"

--- a/tests/test_cross_platform.py
+++ b/tests/test_cross_platform.py
@@ -16,6 +16,15 @@ import engrim.cli as cli
 from engrim.cli import main
 
 WIN_BIN = r"C:\Users\timgo\AppData\Local\Programs\Python\Python313\Scripts\engrim.EXE"
+_REAL_VERIFY = cli._verify_hook_bin        # kept before the autouse stub below can replace it
+
+
+@pytest.fixture(autouse=True)
+def _assume_bin_runs(monkeypatch):
+    """The wiring tests below fake a binary PATH that doesn't exist on this machine, so the live
+    check in `setup` would fail every one of them for the wrong reason. They're about the command
+    STRING setup writes; the check itself is pinned separately in section 4."""
+    monkeypatch.setattr(cli, "_verify_hook_bin", lambda _bin: None)
 
 
 def _run_setup(tmp_path, monkeypatch, which=WIN_BIN):
@@ -151,6 +160,61 @@ def test_no_text_file_is_opened_with_the_locale_codec():
                     and not re.search(r"""["'][rwax]b["']""", line):
                 offenders.append(f"{path.name}:{n}: {line.strip()}")
     assert not offenders, "text-mode open() without encoding=:\n" + "\n".join(offenders)
+
+
+# ------------------------------------------- 4. the checkmark has to be earned, not just printed
+
+def test_setup_fails_loudly_when_the_wired_binary_cannot_run(tmp_path, monkeypatch, capsys):
+    """The bug this whole file documents: every hook ends in `|| true`, so a completely broken
+    install still printed a full column of green checkmarks and the user walked away happy.
+    Setup must verify the binary it just wired and exit non-zero when it can't run."""
+    monkeypatch.setattr(cli, "_verify_hook_bin", lambda _bin: "command not found")
+    monkeypatch.setattr(cli.shutil, "which", lambda _n: WIN_BIN)
+    settings = tmp_path / "settings.json"
+    with pytest.raises(SystemExit) as exc:
+        main(["--db", str(tmp_path / "m.db"), "setup",
+              "--settings", str(settings), "--no-claude-md"])
+    assert exc.value.code != 0, "a non-functional install must not exit clean"
+    out = capsys.readouterr()
+    assert "NOT done" in str(exc.value)
+    assert "Done." not in out.out, "the success line must not print over a failed check"
+    # The hooks are still written — a fixed PATH should not also require re-wiring by hand.
+    assert json.loads(settings.read_text(encoding="utf-8"))["hooks"]
+
+
+def test_setup_flushes_stdout_before_the_failure_gets_the_last_word(tmp_path, monkeypatch):
+    """The failure message is meant to be the LAST thing on screen, under the checkmarks. It goes to
+    stderr (unbuffered) while the checkmarks go to stdout, which is block-buffered whenever it isn't
+    a terminal — so without an explicit flush the verdict lands FIRST under a pipe. Correct-looking
+    in a bare terminal, inverted everywhere else: the same shape as the cp1252 bug above."""
+    flushed = []
+
+    class _TrackingOut(io.StringIO):
+        def flush(self):
+            flushed.append(self.getvalue())
+            super().flush()
+
+    monkeypatch.setattr(cli, "_verify_hook_bin", lambda _bin: "command not found")
+    monkeypatch.setattr(cli.shutil, "which", lambda _n: WIN_BIN)
+    monkeypatch.setattr(cli.sys, "stdout", _TrackingOut())
+    with pytest.raises(SystemExit):
+        main(["--db", str(tmp_path / "m.db"), "setup",
+              "--settings", str(tmp_path / "settings.json"), "--no-claude-md"])
+    assert flushed, "stdout was never flushed, so the verdict can print above the checkmarks"
+    assert "wired SessionStart hook" in flushed[-1], "flushed before the checkmarks were written"
+
+
+def test_verify_hook_bin_accepts_a_binary_that_runs():
+    """The happy path goes through a shell, because it is the quoting that broke, not the binary.
+    Any real interpreter answers `--help` with exit 0, so it stands in for a working install."""
+    assert _REAL_VERIFY(cli._hook_bin(cli.sys.executable)) is None
+
+
+def test_verify_hook_bin_reports_why_a_broken_binary_failed(tmp_path):
+    """A missing binary must come back as a reason string, not an exception or a bare False —
+    that string is what setup shows the user, so an empty one is a silent failure again."""
+    reason = _REAL_VERIFY(cli._hook_bin(str(tmp_path / "nope" / "engrim")))
+    assert isinstance(reason, str) and reason.strip()
 
 
 # ------------------------------------------------------------- project tags must not split in two

--- a/tests/test_engrim.py
+++ b/tests/test_engrim.py
@@ -121,6 +121,64 @@ def test_git_root_tagging_from_subdir(tmp_path, monkeypatch):
     assert os.path.realpath(proj) == os.path.realpath(str(repo))
 
 
+def test_claude_dir_anchors_non_git_workspace(tmp_path, monkeypatch):
+    """A non-repo workspace (no .git) marked by a .claude dir anchors from any subdir to that root.
+
+    This is the edge case that bit in the field: launching from `proj/backend` filed records under
+    the `proj/backend` SIBLING scope while the status line read `proj` — so the count never moved and
+    logging *looked* dead though writes were landing. A .claude dir makes the non-repo root anchor."""
+    import os
+    proj = tmp_path / "workspace"
+    (proj / ".claude").mkdir(parents=True)            # no .git here — pure Claude Code workspace
+    sub = proj / "backend" / "discovery"
+    sub.mkdir(parents=True)
+    db = tmp_path / "m.db"
+    monkeypatch.delenv("ENGRIM_PROJECT", raising=False)
+    monkeypatch.delenv("CLAUDE_PROJECT_TAG", raising=False)
+    monkeypatch.chdir(sub)
+    main(["--db", str(db), "add", "-t", "fact", "-s", "anchored at workspace root"])  # -p auto
+    proj_tag = sqlite3.connect(db).execute("SELECT project FROM memories").fetchone()[0]
+    assert os.path.realpath(proj_tag) == os.path.realpath(str(proj))
+
+
+def test_git_wins_over_nested_claude_marker(tmp_path, monkeypatch):
+    """Nearest marker wins: a .git repo root anchors even if an ancestor also has a .claude dir."""
+    import os
+    outer = tmp_path / "outer"
+    (outer / ".claude").mkdir(parents=True)
+    repo = outer / "repo"
+    (repo / ".git").mkdir(parents=True)
+    sub = repo / "src"
+    sub.mkdir(parents=True)
+    db = tmp_path / "m.db"
+    monkeypatch.delenv("ENGRIM_PROJECT", raising=False)
+    monkeypatch.delenv("CLAUDE_PROJECT_TAG", raising=False)
+    monkeypatch.chdir(sub)
+    main(["--db", str(db), "add", "-t", "fact", "-s", "nearest root wins"])  # -p auto
+    proj_tag = sqlite3.connect(db).execute("SELECT project FROM memories").fetchone()[0]
+    assert os.path.realpath(proj_tag) == os.path.realpath(str(repo))
+
+
+def test_home_claude_never_becomes_catch_all_anchor(tmp_path, monkeypatch):
+    """`~/.claude` must NOT anchor: a non-repo dir under a HOME that has ~/.claude tags to the cwd
+    itself, not to HOME — otherwise every loose project under home collapses into one bucket."""
+    import os
+    home = tmp_path / "home"
+    (home / ".claude").mkdir(parents=True)            # the global ~/.claude
+    loose = home / "loose_project"                    # a project with no marker of its own
+    loose.mkdir()
+    db = tmp_path / "m.db"
+    monkeypatch.delenv("ENGRIM_PROJECT", raising=False)
+    monkeypatch.delenv("CLAUDE_PROJECT_TAG", raising=False)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr("os.path.expanduser", lambda p: p.replace("~", str(home)) if p.startswith("~") else p)
+    monkeypatch.chdir(loose)
+    main(["--db", str(db), "add", "-t", "fact", "-s", "must not collapse to home"])  # -p auto
+    proj_tag = sqlite3.connect(db).execute("SELECT project FROM memories").fetchone()[0]
+    assert os.path.realpath(proj_tag) == os.path.realpath(str(loose))
+    assert os.path.realpath(proj_tag) != os.path.realpath(str(home))
+
+
 def test_env_project_override(tmp_path, monkeypatch):
     """$ENGRIM_PROJECT gives a stable tag (for sharing across host + containers)."""
     db = tmp_path / "m.db"

--- a/tests/test_engrim.py
+++ b/tests/test_engrim.py
@@ -265,3 +265,24 @@ def test_global_layer_read_in_isolation(tmp_path, capsys):
     main(["--db", str(db), "context", "-p", "__global__"])
     out = capsys.readouterr().out
     assert out.count("the one global record") == 1
+
+
+def test_semantic_floor_admits_paraphrase_near_match(tmp_path, capsys, monkeypatch):
+    """A genuine paraphrase scoring in the 0.30-0.35 band (above noise, below the old 0.35 floor) must
+    still be recalled. Query and record share no words, so the only path to a hit is semantic — this
+    pins _SEM_FLOOR at 0.30 and guards against silently raising it back."""
+    # Fake embedder: record -> [1,0,0]; query -> a vector at cosine 0.32 to it (between 0.30 and 0.35).
+    def _fake_embed(text):
+        if "alpha" in text:
+            return [1.0, 0.0, 0.0]
+        if "bravo" in text:
+            return [0.32, 0.94737, 0.0]   # cosine 0.32 with [1,0,0]
+        return [0.0, 0.0, 1.0]
+
+    monkeypatch.setattr("engrim.cli._EMBEDDER_OVERRIDE", (_fake_embed, "test-embed"))
+
+    db = tmp_path / "m.db"
+    main(["--db", str(db), "add", "-p", "/p", "-t", "decision", "-s", "borderline paraphrase target alpha"])
+    capsys.readouterr()
+    main(["--db", str(db), "recall", "-p", "/p", "-q", "bravo charlie delta"])
+    assert "borderline paraphrase target alpha" in capsys.readouterr().out

--- a/tests/test_engrim.py
+++ b/tests/test_engrim.py
@@ -2,6 +2,7 @@
 import json
 import sqlite3
 
+import engrim.cli as cli
 from engrim.cli import main
 
 
@@ -177,6 +178,24 @@ def test_home_claude_never_becomes_catch_all_anchor(tmp_path, monkeypatch):
     proj_tag = sqlite3.connect(db).execute("SELECT project FROM memories").fetchone()[0]
     assert os.path.realpath(proj_tag) == os.path.realpath(str(loose))
     assert os.path.realpath(proj_tag) != os.path.realpath(str(home))
+
+
+def test_marker_walk_never_climbs_past_home(tmp_path, monkeypatch):
+    """The walk STOPS at $HOME. It used to keep climbing, which made the tag depend on whatever sat
+    above home on that machine: a dev box with a marker up there resolved differently than a bare CI
+    runner, and pytest's tmp dir lives UNDER home on Windows, so the walk escaped the fixture and
+    found the developer's own `~/.claude`. Same input, different answer per machine."""
+    import os
+    above = tmp_path / "above"
+    (above / ".git").mkdir(parents=True)              # a repo ABOVE home — must stay invisible
+    home = above / "home"
+    home.mkdir()
+    loose = home / "loose_project"                    # no marker of its own
+    loose.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr("os.path.expanduser",
+                        lambda p: p.replace("~", str(home)) if p.startswith("~") else p)
+    assert cli._git_root(str(loose)) is None, "the walk climbed past $HOME"
 
 
 def test_env_project_override(tmp_path, monkeypatch):

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,0 +1,81 @@
+"""MCP stdio server — drives engrim.mcp_server.serve() with a JSON-RPC script and
+asserts the responses, with no MCP client or network needed."""
+import io
+import json
+import sqlite3
+
+from engrim.cli import connect
+from engrim.mcp_server import serve, TOOLS
+
+
+def _run(conn, requests):
+    """Feed JSON-RPC messages through serve() and return the parsed response frames."""
+    inp = io.StringIO("".join(json.dumps(r) + "\n" for r in requests))
+    out = io.StringIO()
+    serve(conn, inp=inp, out=out)
+    return [json.loads(line) for line in out.getvalue().splitlines() if line.strip()]
+
+
+def test_initialize_and_tools_list(tmp_path):
+    conn = connect(str(tmp_path / "m.db"))
+    resp = _run(conn, [
+        {"jsonrpc": "2.0", "id": 1, "method": "initialize",
+         "params": {"protocolVersion": "2025-06-18"}},
+        {"jsonrpc": "2.0", "method": "notifications/initialized"},  # no response expected
+        {"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+    ])
+    assert len(resp) == 2                                    # the notification produced no frame
+    init = resp[0]["result"]
+    assert init["serverInfo"]["name"] == "engrim"
+    assert init["protocolVersion"] == "2025-06-18"           # client version echoed
+    names = {t["name"] for t in resp[1]["result"]["tools"]}
+    assert names == {"engrim_recall", "engrim_context", "engrim_add"}
+    assert {t["name"] for t in TOOLS} == names
+
+
+def test_add_then_recall_and_context(tmp_path):
+    db = str(tmp_path / "m.db")
+    conn = connect(db)
+    resp = _run(conn, [
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {
+            "name": "engrim_add",
+            "arguments": {"type": "decision", "summary": "retrieval beats stuffing the context window",
+                          "project": "/proj", "tags": ["memory", "design"]}}},
+        {"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": {
+            "name": "engrim_add",
+            "arguments": {"type": "fact", "summary": "unrelated note about coffee", "project": "/proj"}}},
+        {"jsonrpc": "2.0", "id": 3, "method": "tools/call", "params": {
+            "name": "engrim_recall",
+            "arguments": {"query": "retrieval context", "project": "/proj"}}},
+        {"jsonrpc": "2.0", "id": 4, "method": "tools/call", "params": {
+            "name": "engrim_context", "arguments": {"project": "/proj"}}},
+    ])
+
+    add_res = json.loads(resp[0]["result"]["content"][0]["text"])
+    assert add_res["id"] == 1 and add_res["type"] == "decision"
+    # the record really landed in the store
+    c = sqlite3.connect(db)
+    assert c.execute("SELECT summary FROM memories WHERE id=1").fetchone()[0] == \
+        "retrieval beats stuffing the context window"
+    assert json.loads(c.execute("SELECT tags FROM memories WHERE id=1").fetchone()[0]) == ["memory", "design"]
+
+    recall_res = json.loads(resp[2]["result"]["content"][0]["text"])
+    summaries = [r["summary"] for r in recall_res["records"]]
+    assert "retrieval beats stuffing the context window" in summaries
+
+    ctx_res = json.loads(resp[3]["result"]["content"][0]["text"])
+    assert ctx_res["loaded"] >= 1
+    assert any("retrieval beats" in r["summary"] for r in ctx_res["records"])
+
+
+def test_unknown_tool_and_bad_args_are_in_band_errors(tmp_path):
+    conn = connect(str(tmp_path / "m.db"))
+    resp = _run(conn, [
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+         "params": {"name": "engrim_nope", "arguments": {}}},
+        {"jsonrpc": "2.0", "id": 2, "method": "tools/call",
+         "params": {"name": "engrim_add", "arguments": {"type": "bogus", "summary": "x", "project": "/p"}}},
+    ])
+    assert resp[0]["error"]["code"] == -32602                # unknown tool -> JSON-RPC error
+    assert resp[1]["result"]["isError"] is True              # bad tool args -> in-band tool error
+    assert "type must be one of" in resp[1]["result"]["content"][0]["text"]

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -29,7 +29,7 @@ def test_initialize_and_tools_list(tmp_path):
     assert init["serverInfo"]["name"] == "engrim"
     assert init["protocolVersion"] == "2025-06-18"           # client version echoed
     names = {t["name"] for t in resp[1]["result"]["tools"]}
-    assert names == {"engrim_recall", "engrim_context", "engrim_add"}
+    assert names == {"engrim_recall", "engrim_context", "engrim_add", "engrim_review"}
     assert {t["name"] for t in TOOLS} == names
 
 

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,0 +1,143 @@
+"""Tests for `engrim merge` — folding one store's records into another."""
+import shutil
+import sqlite3
+
+import pytest
+
+from engrim.cli import main
+
+
+def _add(db, summary, project="/p", type_="fact"):
+    main(["--db", str(db), "add", "-p", project, "-t", type_, "-s", summary])
+
+
+def _rows(db):
+    c = sqlite3.connect(db)
+    rows = c.execute("SELECT summary, status FROM memories ORDER BY id").fetchall()
+    c.close()
+    return rows
+
+
+def _two_stores(tmp_path):
+    """A and B share two records (B is a copy of A), then each gains one of its own."""
+    a, b = tmp_path / "a.db", tmp_path / "b.db"
+    _add(a, "shared one")
+    _add(a, "shared two")
+    shutil.copyfile(a, b)
+    _add(a, "only in a")
+    _add(b, "only in b")
+    return a, b
+
+
+def test_merge_adds_missing_and_skips_shared(tmp_path, capsys):
+    a, b = _two_stores(tmp_path)
+    main(["--db", str(a), "merge", str(b)])
+    assert "+1 add, ~0 status, 2 skip" in capsys.readouterr().out
+    assert [s for s, _ in _rows(a)] == ["shared one", "shared two", "only in a", "only in b"]
+
+
+def test_merge_is_idempotent(tmp_path, capsys):
+    a, b = _two_stores(tmp_path)
+    main(["--db", str(a), "merge", str(b)])
+    capsys.readouterr()
+    main(["--db", str(a), "merge", str(b)])
+    assert "+0 add, ~0 status, 3 skip" in capsys.readouterr().out
+    assert len(_rows(a)) == 4
+
+
+def test_merge_carries_retirement_and_never_reactivates(tmp_path, capsys):
+    a, b = _two_stores(tmp_path)
+    main(["--db", str(b), "supersede", "--id", "1", "--status", "done"])
+    main(["--db", str(a), "merge", str(b)])
+    assert "~1 status" in capsys.readouterr().out
+    assert _rows(a)[0] == ("shared one", "done")
+    # the other direction: a's still-active copy must not undo b's retirement
+    main(["--db", str(b), "merge", str(a)])
+    assert "~0 status" in capsys.readouterr().out
+    assert _rows(b)[0] == ("shared one", "done")
+
+
+def test_merge_is_a_no_op_in_either_direction_once_converged(tmp_path, capsys):
+    a, b = _two_stores(tmp_path)
+    main(["--db", str(a), "merge", str(b)])
+    main(["--db", str(b), "merge", str(a)])
+    capsys.readouterr()
+    main(["--db", str(a), "merge", str(b)])
+    assert "+0 add, ~0 status" in capsys.readouterr().out
+    assert sorted(_rows(a)) == sorted(_rows(b))
+
+
+def test_merge_dry_run_writes_nothing(tmp_path, capsys):
+    a, b = _two_stores(tmp_path)
+    main(["--db", str(a), "merge", str(b), "--dry-run"])
+    out = capsys.readouterr().out
+    assert "DRY-RUN" in out and "+1 add" in out and "only in b" in out
+    assert len(_rows(a)) == 3
+
+
+def test_merge_project_filter(tmp_path, capsys):
+    a, b = tmp_path / "a.db", tmp_path / "b.db"
+    _add(b, "for p", project="/p")
+    _add(b, "for q", project="/q")
+    main(["--db", str(a), "merge", str(b), "-p", "/p"])
+    assert "+1 add" in capsys.readouterr().out
+    assert [s for s, _ in _rows(a)] == ["for p"]
+
+
+def test_merged_records_are_searchable(tmp_path, capsys):
+    a, b = tmp_path / "a.db", tmp_path / "b.db"
+    _add(a, "seed so the store exists")
+    _add(b, "retrieval beats stuffing the context window")
+    main(["--db", str(a), "merge", str(b)])
+    capsys.readouterr()
+    main(["--db", str(a), "recall", "-p", "/p", "-q", "retrieval context"])
+    assert "retrieval beats stuffing" in capsys.readouterr().out
+
+
+def test_merge_log_rows_dedup_with_and_without_uuid(tmp_path, capsys):
+    a, b = tmp_path / "a.db", tmp_path / "b.db"
+    _add(a, "x")
+    _add(b, "y")
+    c = sqlite3.connect(b)
+    c.execute("INSERT INTO log(ts,project,session,role,content,msg_uuid) VALUES(?,?,?,?,?,?)",
+              ("2026-01-01T00:00:00+00:00", "/p", "s1", "user", "hello", "u-1"))
+    c.commit(); c.close()
+    c = sqlite3.connect(b)
+    c.execute("INSERT INTO log(ts,project,session,role,content,msg_uuid) VALUES(?,?,?,?,?,NULL)",
+              ("2026-01-01T00:00:01+00:00", "/p", "s1", "assistant", "[ran] just check"))
+    c.commit(); c.close()
+    main(["--db", str(a), "merge", str(b)])
+    assert "+2 log" in capsys.readouterr().out
+    main(["--db", str(a), "merge", str(b)])
+    assert "+0 log" in capsys.readouterr().out
+    assert sqlite3.connect(a).execute("SELECT count(*) FROM log").fetchone()[0] == 2
+
+
+def test_merge_leaves_the_source_contents_untouched(tmp_path):
+    a, b = _two_stores(tmp_path)
+    before = b.read_bytes()
+    main(["--db", str(a), "merge", str(b)])
+    assert b.read_bytes() == before
+    assert _rows(b) == [("shared one", "active"), ("shared two", "active"), ("only in b", "active")]
+
+
+def test_merge_rejects_missing_and_non_store_sources(tmp_path):
+    a = tmp_path / "a.db"
+    _add(a, "x")
+    with pytest.raises(SystemExit):
+        main(["--db", str(a), "merge", str(tmp_path / "nope.db")])
+    junk = tmp_path / "junk.db"
+    junk.write_text("not a database")
+    with pytest.raises(SystemExit):
+        main(["--db", str(a), "merge", str(junk)])
+    empty = tmp_path / "empty.db"
+    sqlite3.connect(empty).execute("CREATE TABLE t(x)")
+    with pytest.raises(SystemExit):
+        main(["--db", str(a), "merge", str(empty)])
+
+
+def test_merge_rejects_self(tmp_path):
+    a = tmp_path / "a.db"
+    _add(a, "x")
+    with pytest.raises(SystemExit):
+        main(["--db", str(a), "merge", str(a)])

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,65 @@
+"""Packaging + plugin-install guards.
+
+Two things that go stale silently and are only noticed by someone installing fresh: the version
+pinned in four separate manifests, and the plugin's assumption about where a venv puts its binaries.
+The plugin route was 100% broken on Windows because of the second one.
+"""
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+import engrim
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOKS = ROOT / "plugin" / "hooks" / "hooks.json"
+BOOTSTRAP = ROOT / "plugin" / "scripts" / "engrim-bootstrap.sh"
+MARKETPLACE = ROOT / ".claude-plugin" / "marketplace.json"
+PLUGIN_MANIFEST = ROOT / "plugin" / ".claude-plugin" / "plugin.json"
+
+pytestmark = pytest.mark.skipif(not HOOKS.exists(), reason="running outside the source tree")
+
+
+def _text(p):
+    return p.read_text(encoding="utf-8")
+
+
+def test_every_manifest_pins_the_released_version():
+    """These drifted to 1.1.0 while the package shipped 1.2.0 — so the plugin installed a version
+    behind the one being announced, and the marketplace advertised the wrong number."""
+    v = engrim.__version__
+    assert json.loads(_text(PLUGIN_MANIFEST))["version"] == v
+    mk = json.loads(_text(MARKETPLACE))
+    assert mk["metadata"]["version"] == v
+    assert [p["version"] for p in mk["plugins"]] == [v]
+    assert re.search(r"ENGRIM_PLUGIN_SOURCE:-engrim==([0-9][^}\"]*)\}", _text(BOOTSTRAP)).group(1) == v
+
+
+def test_plugin_hooks_resolve_the_binary_on_both_venv_layouts():
+    """A venv writes entry points to bin/ on POSIX and Scripts/*.exe on Windows. Only bin/ was
+    checked, so on Windows all four hooks silently no-opped forever."""
+    cfg = json.loads(_text(HOOKS))
+    invocations = [h["command"] for groups in cfg["hooks"].values()
+                   for g in groups for h in g["hooks"] if "/venv/" in h["command"]]
+    assert len(invocations) == 4, "expected one engrim invocation per lifecycle event"
+    for cmd in invocations:
+        assert "/venv/bin/engrim" in cmd
+        assert "/venv/Scripts/engrim.exe" in cmd, f"no Windows fallback: {cmd}"
+        assert cmd.endswith("|| true"), "a hook must never fail the session"
+
+
+def test_bootstrap_checks_both_venv_layouts_and_never_fails_the_session():
+    sh = _text(BOOTSTRAP)
+    assert '"$VENV/Scripts/$1.exe"' in sh, "bootstrap only looks in bin/ — Windows installs no-op"
+    assert "command -v python3 || command -v python" in sh, "Windows ships `python`, not `python3`"
+    assert sh.rstrip().endswith("exit 0"), "bootstrap must always exit 0"
+
+
+def test_hook_wiring_covers_every_lifecycle_event():
+    """setup and the plugin are two routes to the same wiring — they must not drift apart."""
+    from engrim.cli import cmd_setup  # noqa: F401  (import guard: the module must load)
+    import engrim.cli as cli
+    src = Path(cli.__file__).read_text(encoding="utf-8")
+    wired = set(re.findall(r'"(SessionStart|SessionEnd|Stop|UserPromptSubmit)":', src))
+    assert wired == set(json.loads(_text(HOOKS))["hooks"])

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,123 @@
+"""Tests for Agent Provenance Tracking in SQLite Schema and Display."""
+import json
+import sqlite3
+import pytest
+
+from engrim.cli import connect, main, add_memory
+from engrim.mcp_server import serve
+
+
+def test_provenance_storage_and_defaults(tmp_path):
+    db = str(tmp_path / "m.db")
+    conn = connect(db)
+
+    id1 = add_memory(
+        conn,
+        project="/p",
+        type="decision",
+        summary="Antigravity decision",
+        origin_agent="antigravity",
+    )
+    id2 = add_memory(
+        conn,
+        project="/p",
+        type="fact",
+        summary="Claude fact",
+        origin_agent="claude-code",
+    )
+    id3 = add_memory(
+        conn,
+        project="/p",
+        type="decision",
+        summary="Cursor decision",
+        origin_agent="cursor",
+    )
+    id4 = add_memory(
+        conn,
+        project="/p",
+        type="fact",
+        summary="Legacy or untagged fact",
+        origin_agent=None,
+    )
+    conn.close()
+
+    c = sqlite3.connect(db)
+    rows = dict(c.execute("SELECT id, origin_agent FROM memories").fetchall())
+    assert rows[id1] == "antigravity"
+    assert rows[id2] == "claude-code"
+    assert rows[id3] == "cursor"
+    assert rows[id4] is None
+    c.close()
+
+
+def test_provenance_cli_add(tmp_path, capsys):
+    db = str(tmp_path / "m.db")
+    main(["--db", db, "add", "-p", "/p", "-t", "decision", "-s", "cli decision"])
+    c = sqlite3.connect(db)
+    assert c.execute("SELECT origin_agent FROM memories WHERE id=1").fetchone()[0] == "cli"
+
+    main(["--db", db, "add", "-p", "/p", "-t", "decision", "-s", "agy decision", "--origin-agent", "antigravity"])
+    assert c.execute("SELECT origin_agent FROM memories WHERE id=2").fetchone()[0] == "antigravity"
+    c.close()
+
+
+def test_provenance_display_in_context_and_list(tmp_path, capsys):
+    db = str(tmp_path / "m.db")
+    conn = connect(db)
+    add_memory(
+        conn,
+        project="/p",
+        type="decision",
+        summary="Inverted stop loss matrix for extreme tails",
+        origin_agent="antigravity",
+    )
+    add_memory(
+        conn,
+        project="/p",
+        type="fact",
+        summary="Untagged plain fact",
+        origin_agent=None,
+    )
+    conn.close()
+
+    # Verify engrim context output format
+    main(["--db", db, "context", "-p", "/p"])
+    out = capsys.readouterr().out
+    assert "[DECISION] (via Antigravity): Inverted stop loss matrix for extreme tails" in out
+    assert "- #2 Untagged plain fact" in out
+
+    # Verify engrim list output format
+    main(["--db", db, "list", "-p", "/p"])
+    out_list = capsys.readouterr().out
+    assert "(via Antigravity)" in out_list
+    assert "#1 [decision/active] (via Antigravity)" in out_list
+
+
+def test_schema_migration_adds_origin_agent(tmp_path):
+    # Simulate a pre-1.3.0 database without origin_agent column
+    db_file = tmp_path / "legacy.db"
+    conn = sqlite3.connect(str(db_file))
+    conn.execute(
+        """
+        CREATE TABLE memories (
+            id INTEGER PRIMARY KEY, ts TEXT NOT NULL, project TEXT NOT NULL,
+            type TEXT NOT NULL, summary TEXT NOT NULL, detail TEXT,
+            status TEXT NOT NULL DEFAULT 'active', tags TEXT, links TEXT, source TEXT
+        );
+        """
+    )
+    conn.execute(
+        "INSERT INTO memories(id, ts, project, type, summary) VALUES(1, '2026-08-01', '/p', 'fact', 'legacy item')"
+    )
+    conn.commit()
+    conn.close()
+
+    # Opening with connect() must auto-migrate the table
+    c2 = connect(str(db_file))
+    cols = {r[1] for r in c2.execute("PRAGMA table_info(memories)")}
+    assert "origin_agent" in cols
+    # Preserves existing rows
+    r = c2.execute("SELECT summary, origin_agent FROM memories WHERE id=1").fetchone()
+    assert r[0] == "legacy item"
+    assert r[1] is None
+    c2.close()

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,88 @@
+"""Tests for universal multi-agent setup (Antigravity, Claude, Cursor)."""
+import json
+import os
+import pytest
+
+from engrim.cli import main
+
+
+def test_setup_agy_dry_run(tmp_path, monkeypatch, capsys):
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("USERPROFILE", str(fake_home))
+
+    main(["--db", str(tmp_path / "m.db"), "setup", "--agy", "--dry-run"])
+    out = capsys.readouterr().out
+    assert "[dry-run] Would wire Antigravity hooks" in out
+    assert "[dry-run] Would deploy canonical Antigravity skill" in out
+    assert "[dry-run] Would register MCP server" in out
+
+    # Verify dry run wrote nothing
+    assert not (fake_home / ".gemini").exists()
+
+
+def test_setup_agy_execution(tmp_path, monkeypatch, capsys):
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("USERPROFILE", str(fake_home))
+
+    main(["--db", str(tmp_path / "m.db"), "setup", "--agy"])
+    out = capsys.readouterr().out
+    assert "✓ wired PreInvocation & Stop hooks" in out
+    assert "✓ deployed canonical Antigravity skill" in out
+    assert "✓ registered MCP server" in out
+
+    # Verify hooks.json
+    hooks_file = fake_home / ".gemini" / "config" / "hooks.json"
+    assert hooks_file.exists()
+    hooks_cfg = json.loads(hooks_file.read_text(encoding="utf-8"))
+    assert "engrim" in hooks_cfg
+    assert any("hook --agent agy --event boot" in h["command"] for h in hooks_cfg["engrim"]["PreInvocation"])
+    assert any("hook --agent agy --event stop" in h["command"] for h in hooks_cfg["engrim"]["Stop"])
+
+    # Verify SKILL.md
+    skill_file = fake_home / ".gemini" / "config" / "skills" / "engrim" / "SKILL.md"
+    assert skill_file.exists()
+    skill_content = skill_file.read_text(encoding="utf-8")
+    assert "name: engrim" in skill_content
+    assert "engrim_recall" in skill_content
+    assert "engrim_review" in skill_content
+
+    # Verify MCP configs
+    mcp_file = fake_home / ".gemini" / "antigravity-cli" / "mcp_config.json"
+    assert mcp_file.exists()
+    mcp_cfg = json.loads(mcp_file.read_text(encoding="utf-8"))
+    assert "engrim" in mcp_cfg["mcpServers"]
+    assert mcp_cfg["mcpServers"]["engrim"]["args"] == ["serve", "--mcp"]
+
+
+def test_setup_cursor_execution(tmp_path, monkeypatch, capsys):
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("USERPROFILE", str(fake_home))
+
+    main(["--db", str(tmp_path / "m.db"), "setup", "--cursor"])
+    out = capsys.readouterr().out
+    assert "✓ registered Cursor MCP entry" in out
+
+    cursor_mcp = fake_home / ".cursor" / "mcp.json"
+    assert cursor_mcp.exists()
+    cursor_cfg = json.loads(cursor_mcp.read_text(encoding="utf-8"))
+    assert "engrim" in cursor_cfg["mcpServers"]
+    assert cursor_cfg["mcpServers"]["engrim"]["args"] == ["serve", "--mcp"]
+
+
+def test_setup_auto_detects_gemini(tmp_path, monkeypatch, capsys):
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    (fake_home / ".gemini").mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("USERPROFILE", str(fake_home))
+
+    main(["--db", str(tmp_path / "m.db"), "setup"])
+    out = capsys.readouterr().out
+    assert "Auto-detected environments: Antigravity (~/.gemini)" in out
+    assert (fake_home / ".gemini" / "config" / "hooks.json").exists()

--- a/tests/test_v04.py
+++ b/tests/test_v04.py
@@ -176,6 +176,37 @@ def test_minder_silent_on_trivial_prompt(tmp_path, capsys, monkeypatch):
     assert ctx == ""  # gated: too few substantive terms -> spend nothing
 
 
+def test_minder_nudges_curation_when_backlog_builds(tmp_path, capsys, monkeypatch):
+    """Mid-session backstop: once uncaptured decisions cross the floor, the minder appends an auto-curate
+    directive to the AGENT — even when no memory slice is relevant to the prompt (so it never gets lost)."""
+    db = tmp_path / "m.db"
+    main(["--db", str(db), "add", "-p", "/p", "-t", "fact", "-s", "seed to init schema"])
+    for d in ["We decided to use Kafka for the billing pipeline.",
+              "We chose Postgres as the system of record.",
+              "We settled on gRPC between the new services.",
+              "We agreed on dropping the legacy cron scheduler."]:
+        _insert_log(str(db), "/p", d)
+    capsys.readouterr()
+    monkeypatch.setattr("sys.stdin",
+                        io.StringIO(json.dumps({"prompt": "unrelated question about the weather forecast"})))
+    main(["--db", str(db), "assist", "-p", "/p"])
+    ctx = json.loads(capsys.readouterr().out)["hookSpecificOutput"]["additionalContext"]
+    assert "auto-curate" in ctx and "engrim add" in ctx
+
+
+def test_minder_no_curation_nudge_below_floor(tmp_path, capsys, monkeypatch):
+    """A small backlog (under the floor) must NOT trip the curation nudge — no nagging on ordinary work."""
+    db = tmp_path / "m.db"
+    main(["--db", str(db), "add", "-p", "/p", "-t", "fact", "-s", "seed to init schema"])
+    _insert_log(str(db), "/p", "We decided to use Kafka for the billing pipeline.")
+    capsys.readouterr()
+    monkeypatch.setattr("sys.stdin",
+                        io.StringIO(json.dumps({"prompt": "unrelated question about the weather forecast"})))
+    main(["--db", str(db), "assist", "-p", "/p"])
+    ctx = json.loads(capsys.readouterr().out)["hookSpecificOutput"]["additionalContext"]
+    assert "auto-curate" not in ctx
+
+
 def test_sessionstart_recovers_orphaned_transcript(tmp_path, capsys, monkeypatch):
     """A crash/hard-close skips Stop+SessionEnd; the next SessionStart must sweep up the lost tail."""
     db = tmp_path / "m.db"
@@ -378,6 +409,51 @@ def test_context_recent_tail_dedupes_captured_decision(tmp_path, capsys):
     out = capsys.readouterr().out
     # the only decision candidate is already curated -> tail is empty -> no RECENT section (no dup noise)
     assert "[RECENT" not in out
+
+
+# --- auto-curate on boot: recover a session that closed (window/limit) before curating ---
+
+def test_hook_emits_autocurate_directive_for_uncaptured_decision(tmp_path, capsys):
+    """A hard window-close/limit-expiry can't curate itself, but the raw log survives. The NEXT
+    session's `engrim hook` injects an AUTO-CURATE directive telling the agent to promote the
+    uncaptured decisions — zero user interaction. Manual `context` keeps the human-facing nudge."""
+    db = tmp_path / "m.db"
+    main(["--db", str(db), "add", "-p", "/p", "-t", "fact", "-s", "office plants need weekly water"])
+    _insert_log(str(db), "/p", "We decided to migrate the billing service to Kafka for throughput.")
+    capsys.readouterr()
+    main(["--db", str(db), "hook", "--no-sync", "-p", "/p"])
+    boot = json.loads(capsys.readouterr().out.strip())["hookSpecificOutput"]["additionalContext"]
+    assert "AUTO-CURATE" in boot and "engrim review" in boot
+    # the manual `context` path must NOT emit the agent directive — it keeps the gentle human nudge
+    capsys.readouterr()
+    main(["--db", str(db), "context", "-p", "/p"])
+    manual = capsys.readouterr().out
+    assert "AUTO-CURATE" not in manual and "worth capturing" in manual
+
+
+def test_hook_no_autocurate_directive_when_captured(tmp_path, capsys):
+    """Self-limiting + dedup-safe: once the decision is curated, the boot directive stops firing,
+    so repeated session boots don't loop on already-captured work."""
+    db = tmp_path / "m.db"
+    main(["--db", str(db), "add", "-p", "/p", "-t", "decision",
+          "-s", "migrate the billing service to Kafka for throughput"])
+    _insert_log(str(db), "/p", "We decided to migrate the billing service to Kafka for throughput.")
+    capsys.readouterr()
+    main(["--db", str(db), "hook", "--no-sync", "-p", "/p"])
+    boot = json.loads(capsys.readouterr().out.strip())["hookSpecificOutput"]["additionalContext"]
+    assert "AUTO-CURATE" not in boot
+
+
+def test_hook_no_autocurate_directive_for_pure_open_task(tmp_path, capsys):
+    """A pure open-loop (continuity cue, no decision) must NOT trip the directive — it surfaces in the
+    recency tail for continuity, but engrim won't tell the agent to curate ordinary work-in-progress."""
+    db = tmp_path / "m.db"
+    main(["--db", str(db), "add", "-p", "/p", "-t", "fact", "-s", "seed"])
+    _insert_log(str(db), "/p", "Still need to run pass three next; we'll pick this up later.")
+    capsys.readouterr()
+    main(["--db", str(db), "hook", "--no-sync", "-p", "/p"])
+    boot = json.loads(capsys.readouterr().out.strip())["hookSpecificOutput"]["additionalContext"]
+    assert "AUTO-CURATE" not in boot
 
 
 # --- continue-as-clear: the pinned resume cursor + open-task continuity tail ---

--- a/tests/test_v04.py
+++ b/tests/test_v04.py
@@ -380,6 +380,63 @@ def test_context_recent_tail_dedupes_captured_decision(tmp_path, capsys):
     assert "[RECENT" not in out
 
 
+# --- continue-as-clear: the pinned resume cursor + open-task continuity tail ---
+
+def test_context_pins_resume_cursor_first_and_untruncated(tmp_path, capsys):
+    """A record tagged resume-pointer leads the pack under [▶ RESUME HERE] and is never truncated,
+    so a fresh session after /clear opens on exactly where we left off."""
+    db = tmp_path / "m.db"
+    # a long cursor summary (> _BOOT_SUMMARY_CAP) with a unique sentinel at the very end
+    long_cursor = ("RESUME HERE: next action is discovery pass #3 — gate HMDA denominators, "
+                   "winsorize small-county ratios, add RUCC, then run leave-one-state-out. " * 3
+                   + "TAILSENTINEL_XYZ")
+    assert len(long_cursor) > 200
+    main(["--db", str(db), "add", "-p", "/p", "-t", "state", "-s", long_cursor, "--tags", "resume-pointer"])
+    main(["--db", str(db), "add", "-p", "/p", "-t", "decision", "-s", "we chose postgres for billing"])
+    capsys.readouterr()
+    main(["--db", str(db), "context", "-p", "/p"])
+    out = capsys.readouterr().out
+    assert "[▶ RESUME HERE]" in out
+    # the cursor is untruncated -> its end-sentinel survives (other long records would be clipped)
+    assert "TAILSENTINEL_XYZ" in out
+    # and it leads: the RESUME HERE header precedes the regular type sections
+    assert out.index("[▶ RESUME HERE]") < out.index("[DECISION]")
+
+
+def test_context_no_resume_section_without_tag(tmp_path, capsys):
+    """No resume-pointer record -> no RESUME HERE section; the pack behaves exactly as before."""
+    db = tmp_path / "m.db"
+    main(["--db", str(db), "add", "-p", "/p", "-t", "decision", "-s", "we chose postgres for billing"])
+    capsys.readouterr()
+    main(["--db", str(db), "context", "-p", "/p"])
+    assert "[▶ RESUME HERE]" not in capsys.readouterr().out
+
+
+def test_recent_tail_surfaces_open_task_cue(tmp_path, capsys):
+    """A mid-task open loop with no decision cue ('we'll pick this up later: still need to run pass #3')
+    still surfaces in the recency tail, so /clear can't drop where we left off."""
+    db = tmp_path / "m.db"
+    main(["--db", str(db), "add", "-p", "/p", "-t", "fact", "-s", "office plants need weekly water"])
+    _insert_log(str(db), "/p", "We'll pick this up later: still need to run discovery pass three.")
+    capsys.readouterr()
+    main(["--db", str(db), "context", "-p", "/p"])
+    out = capsys.readouterr().out
+    assert "[RECENT" in out and "pass three" in out
+
+
+def test_open_task_cue_does_not_inflate_clear_nudge(tmp_path, capsys):
+    """The 'safe to clear?' nudge counts real decisions only — a pure open loop must NOT trip it,
+    or engrim would nag on ordinary work-in-progress."""
+    db = tmp_path / "m.db"
+    main(["--db", str(db), "add", "-p", "/p", "-t", "fact", "-s", "seed"])
+    _insert_log(str(db), "/p", "Still need to run pass three next; we'll pick this up later.")
+    capsys.readouterr()
+    main(["--db", str(db), "context", "-p", "/p"])
+    out = capsys.readouterr().out
+    # the nudge ("✎ … worth capturing before your next /clear") must be absent; the verdict is clear-safe
+    assert "safe to /clear" in out and "worth capturing" not in out
+
+
 # --- ambient status line: the user can SEE engrim working, out-of-band ---
 
 def test_statusline_ready_when_empty(tmp_path, capsys, monkeypatch):

--- a/tests/test_v04.py
+++ b/tests/test_v04.py
@@ -115,6 +115,45 @@ def test_log_hook_reads_stdin(tmp_path, monkeypatch):
     assert c.execute("SELECT COUNT(*) FROM log WHERE project='/p'").fetchone()[0] == 2
 
 
+def test_log_hook_resolves_project_from_payload_not_process_cwd(tmp_path, monkeypatch):
+    """One Claude session is one transcript file; it must land in ONE project bucket even if the hook
+    process's cwd drifts (e.g. it inherits a cwd a tool subprocess chdir'd into). The Stop hook must
+    resolve the project from the workspace Claude Code reports in the payload, not os.getcwd() — else
+    the session forks across buckets, each with its own cursor, and the status line's count freezes."""
+    db = tmp_path / "m.db"
+    t = _transcript(tmp_path)
+    workspace = tmp_path / "the_session_project"; workspace.mkdir()
+    drifted = tmp_path / "some_other_repo"; drifted.mkdir()
+    monkeypatch.delenv("ENGRIM_PROJECT", raising=False)
+    monkeypatch.delenv("CLAUDE_PROJECT_TAG", raising=False)
+    monkeypatch.setattr("os.getcwd", lambda: str(drifted))          # hook process cwd has drifted away
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(
+        {"transcript_path": str(t), "session_id": "s", "cwd": str(workspace)})))
+    main(["--db", str(db), "log", "--hook"])                        # no -p: must auto-resolve
+    c = sqlite3.connect(db)
+    assert c.execute("SELECT COUNT(*) FROM log WHERE project=?", (str(workspace),)).fetchone()[0] == 2
+    assert c.execute("SELECT COUNT(*) FROM log WHERE project=?", (str(drifted),)).fetchone()[0] == 0
+
+
+def test_log_ingest_cursor_advances_to_eof_and_is_stable(tmp_path):
+    """The byte-offset cursor advances to true EOF, and a re-run on the unchanged file holds there —
+    no re-reading old ground, no duplicate rows. (The monotonic guard additionally protects a
+    concurrent run from rewinding it; that path needs real concurrency and is covered by reasoning.)"""
+    db = tmp_path / "m.db"
+    t = _transcript(tmp_path)
+    okey = "log_offset:" + t.stem
+    main(["--db", str(db), "log", "--from-transcript", str(t), "-p", "/p"])
+    c = sqlite3.connect(db)
+    first = int(c.execute("SELECT value FROM engrim_meta WHERE project='/p' AND key=?", (okey,)).fetchone()[0])
+    assert first == t.stat().st_size                                # advanced to true EOF
+    c.close()
+    main(["--db", str(db), "log", "--from-transcript", str(t), "-p", "/p"])  # re-run, unchanged file
+    c = sqlite3.connect(db)
+    after = int(c.execute("SELECT value FROM engrim_meta WHERE project='/p' AND key=?", (okey,)).fetchone()[0])
+    assert after == first                                           # stable, not rewound
+    assert c.execute("SELECT COUNT(*) FROM log WHERE project='/p'").fetchone()[0] == 2  # no dupes
+
+
 def test_minder_injects_relevant_slice(tmp_path, capsys, monkeypatch):
     db = tmp_path / "m.db"
     main(["--db", str(db), "add", "-p", "/p", "-t", "decision", "-s", "chose postgres for billing integrity"])

--- a/tests/test_v04.py
+++ b/tests/test_v04.py
@@ -1,8 +1,10 @@
 """Tests for the v0.4 surface: seed-once sync, the transcript log, and the minder."""
 import io
 import json
+import re
 import sqlite3
 
+import engrim.cli as cli
 from engrim.cli import main
 
 
@@ -573,3 +575,149 @@ def test_statusline_narration_does_not_trip_capture_nudge(tmp_path, capsys, monk
     main(["--db", str(db), "statusline", "-p", "/p"])
     out = capsys.readouterr().out
     assert "to capture" not in out and "clear-safe" in out
+
+
+# --- one captured-check, one window: the bar and `review` must never disagree (#747) -------------
+#
+# The bug: on a host WITH an embedder, `review` scored a paraphrase as captured while the status bar
+# and the minder's auto-curate nudge were hard-wired to the LEXICAL check and kept counting it. So
+# curating a decision in your own words never cleared the nudge — it just accumulated and cried wolf.
+
+def _backdate_records(db, ts):
+    """Age the curated records so the capture floor sits BEHIND the log turns — i.e. the decisions
+    were logged after the last `add`, which is the situation the recency net exists for."""
+    con = sqlite3.connect(db)
+    con.execute("UPDATE memories SET ts = ?", (ts,))
+    con.commit()
+    con.close()
+
+
+def _concept_embedder():
+    """Deterministic toy embedder with a synonym notion, so the SEMANTIC tier is what's under test:
+    'kafka' and 'streaming backbone' land on the same axis despite sharing no words."""
+    concepts = (("kafka", "streaming", "broker", "throughput"),
+                ("postgres", "relational", "sql"),
+                ("plants", "water", "office"))
+
+    def fn(text):
+        low = (text or "").lower()
+        v = [float(sum(w in low for w in group)) for group in concepts]
+        return v if any(v) else [0.001, 0.0, 0.0]
+    return fn
+
+
+def test_paraphrased_capture_clears_the_bar_not_just_review(tmp_path, monkeypatch):
+    """A decision curated in DIFFERENT WORDS is captured. Both surfaces must say so."""
+    db = tmp_path / "m.db"
+    monkeypatch.setattr(cli, "_EMBEDDER_OVERRIDE", (_concept_embedder(), "toy"), raising=False)
+    main(["--db", str(db), "add", "-p", "/p", "-t", "decision",
+          "-s", "billing moves onto a streaming backbone for throughput"])
+    _insert_log(str(db), "/p", "We decided to migrate the billing service to Kafka.")
+
+    conn = cli.connect(str(db))
+    snip = "We decided to migrate the billing service to Kafka."
+    # the paraphrase does NOT clear the lexical bar — semantics are the only thing that can catch it
+    assert not cli._lexical_overlap_captured(conn, "/p", snip)
+    assert cli._is_captured(conn, "/p", snip)
+    assert cli._uncaptured_count(conn, "/p") == 0        # pre-fix this was 1, forever
+
+
+def test_bar_and_review_agree_on_the_same_db(tmp_path, capsys, monkeypatch):
+    """The invariant: the ambient count never nags about something `review` calls clean. `review` may
+    surface MORE (it adds cue-less semantic detection); it may never surface fewer."""
+    db = tmp_path / "m.db"
+    monkeypatch.setattr(cli, "_EMBEDDER_OVERRIDE", (_concept_embedder(), "toy"), raising=False)
+    main(["--db", str(db), "add", "-p", "/p", "-t", "decision",
+          "-s", "billing moves onto a streaming backbone for throughput"])
+    _insert_log(str(db), "/p", "We decided to migrate the billing service to Kafka.")
+    _insert_log(str(db), "/p", "We chose to water the office plants weekly.",
+                ts="2026-06-20T09:05:00")
+    capsys.readouterr()
+
+    conn = cli.connect(str(db))
+    bar = cli._uncaptured_count(conn, "/p")
+    main(["--db", str(db), "review", "-p", "/p"])
+    out = capsys.readouterr().out
+    rev = int(re.search(r"(\d+) may not be", out).group(1))
+    assert bar <= rev, f"bar nags about {bar} but review only flags {rev}"
+    assert bar == rev == 1          # the plants decision is uncaptured; Kafka is covered by paraphrase
+
+
+def test_uncaptured_memo_invalidates_when_the_store_changes(tmp_path):
+    """The count is memoized for the status bar's sake — it must still drop the moment the decision
+    is curated, or we've just cached the wolf-crying."""
+    db = tmp_path / "m.db"
+    main(["--db", str(db), "add", "-p", "/p", "-t", "fact", "-s", "seed record"])
+    _insert_log(str(db), "/p", "We decided to migrate the billing service to Kafka for throughput.")
+    conn = cli.connect(str(db))
+    assert cli._uncaptured_count(conn, "/p") == 1
+    assert cli._uncaptured_count(conn, "/p") == 1            # served from the memo, same answer
+    main(["--db", str(db), "add", "-p", "/p", "-t", "decision",
+          "-s", "migrate the billing service to Kafka for throughput"])
+    conn = cli.connect(str(db))
+    assert cli._uncaptured_count(conn, "/p") == 0            # memo invalidated by the new record
+
+
+def test_uncaptured_memo_invalidates_on_a_new_log_turn(tmp_path):
+    db = tmp_path / "m.db"
+    main(["--db", str(db), "add", "-p", "/p", "-t", "fact", "-s", "seed record"])
+    conn = cli.connect(str(db))
+    assert cli._uncaptured_count(conn, "/p") == 0
+    _insert_log(str(db), "/p", "We decided to move the scheduler onto a cron worker.",
+                ts="2026-06-21T10:00:00")
+    conn = cli.connect(str(db))
+    assert cli._uncaptured_count(conn, "/p") == 1            # a fresh decision must break the memo
+
+
+def test_review_window_extends_back_to_the_capture_floor(tmp_path, capsys):
+    """Second half of the divergence: `review` used a flat last-k window while the bar extended back
+    to the last capture, so the bar could count a turn `review` never scanned."""
+    db = tmp_path / "m.db"
+    main(["--db", str(db), "add", "-p", "/p", "-t", "fact", "-s", "seed record"])
+    _backdate_records(str(db), "2026-06-20T09:00:00")        # the last capture happened, then work continued
+    _insert_log(str(db), "/p", "We decided to move the scheduler onto a cron worker.",
+                ts="2026-06-21T10:00:00")
+    for i in range(5):                       # chatter pushes the decision out of a tiny lean window
+        _insert_log(str(db), "/p", f"Running check number {i}.", ts=f"2026-06-21T11:0{i}:00")
+    capsys.readouterr()
+    main(["--db", str(db), "review", "-p", "/p", "-k", "2"])
+    out = capsys.readouterr().out
+    assert "cron worker" in out and "may not be" in out
+    conn = cli.connect(str(db))
+    assert cli._uncaptured_count(conn, "/p", scan=2) == 1     # and the bar sees exactly the same turn
+
+
+# --- capture at the MOMENT of the decision, not at wrap time (Tim, 2026-08-11) -------------------
+
+def test_minder_nudges_at_two_decisions(tmp_path, capsys, monkeypatch):
+    """Floor lowered 4 -> 2: a wrap-time-only habit loses exactly the long sessions worth keeping, so
+    the mid-session nudge has to fire while there's still a session to fire into."""
+    db = tmp_path / "m.db"
+    main(["--db", str(db), "add", "-p", "/p", "-t", "fact", "-s", "seed to init schema"])
+    _insert_log(str(db), "/p", "We decided to use Kafka for the billing pipeline.")
+    _insert_log(str(db), "/p", "We chose Postgres as the system of record.",
+                ts="2026-06-20T09:05:00")
+    capsys.readouterr()
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"prompt": "unrelated weather question"})))
+    main(["--db", str(db), "assist", "-p", "/p"])
+    ctx = json.loads(capsys.readouterr().out)["hookSpecificOutput"]["additionalContext"]
+    assert "auto-curate" in ctx
+
+
+def test_curate_directives_ask_for_measurements_not_conclusions(tmp_path, capsys, monkeypatch):
+    """Records that state what was MEASURED outlive records that state what was concluded, so both
+    the mid-session nudge and the boot recovery directive have to say so."""
+    db = tmp_path / "m.db"
+    main(["--db", str(db), "add", "-p", "/p", "-t", "fact", "-s", "seed to init schema"])
+    for i, d in enumerate(["We decided to use Kafka for the billing pipeline.",
+                           "We chose Postgres as the system of record."]):
+        _insert_log(str(db), "/p", d, ts=f"2026-06-20T09:0{i}:00")
+    capsys.readouterr()
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"prompt": "unrelated weather question"})))
+    main(["--db", str(db), "assist", "-p", "/p"])
+    ctx = json.loads(capsys.readouterr().out)["hookSpecificOutput"]["additionalContext"]
+    assert "MEASURED" in ctx
+
+    capsys.readouterr()
+    main(["--db", str(db), "hook", "--no-sync", "-p", "/p"])   # boot path sets agent_directive itself
+    assert "MEASURED" in capsys.readouterr().out

--- a/tests/test_v04.py
+++ b/tests/test_v04.py
@@ -762,3 +762,78 @@ def test_semantic_verdict_invalidates_when_curation_changes(tmp_path, monkeypatc
           "-s", "billing moves onto a streaming backbone for throughput"])   # a PARAPHRASE
     conn = cli.connect(str(db))
     assert cli._uncaptured_count(conn, "/p") == 0
+
+
+# --- action lines: source the WORK, not just the chat (#756) -------------------------------------
+
+def _tool_turn(tmp_path, *blocks, uuid="t1"):
+    p = tmp_path / f"{uuid}.jsonl"
+    p.write_text(json.dumps({
+        "type": "assistant", "uuid": uuid, "sessionId": "s", "timestamp": "2026-01-01T00:00:00Z",
+        "message": {"role": "assistant", "content": list(blocks)}}) + "\n", encoding="utf-8")
+    return p
+
+
+def test_state_changing_tool_calls_become_searchable_action_lines(tmp_path):
+    db = tmp_path / "m.db"
+    t = _tool_turn(tmp_path,
+                   {"type": "text", "text": "Shipping it."},
+                   {"type": "tool_use", "name": "Edit", "input": {"file_path": "/repo/src/cli.py"}},
+                   {"type": "tool_use", "name": "Bash",
+                    "input": {"command": "git commit -m 'release 1.2.0'", "description": "Commit the release"}})
+    main(["--db", str(db), "log", "--from-transcript", str(t), "-p", "/p"])
+    c = sqlite3.connect(db)
+    content = c.execute("SELECT content FROM log WHERE project='/p'").fetchone()[0]
+    assert "Shipping it." in content                       # prose still kept
+    assert "[changed] /repo/src/cli.py" in content
+    assert "[ran] Commit the release" in content
+
+
+def test_investigation_is_not_logged_as_an_action(tmp_path):
+    """Greps and reads are how you FIND things, not what you did — including them buried the signal."""
+    db = tmp_path / "m.db"
+    t = _tool_turn(tmp_path,
+                   {"type": "tool_use", "name": "Read", "input": {"file_path": "/repo/src/cli.py"}},
+                   {"type": "tool_use", "name": "Bash",
+                    "input": {"command": "grep -rn foo src/", "description": "Search for foo"}},
+                   {"type": "tool_result", "content": "lots and lots of output"})
+    main(["--db", str(db), "log", "--from-transcript", str(t), "-p", "/p"])
+    c = sqlite3.connect(db)
+    assert (c.execute("SELECT content FROM log WHERE project='/p'").fetchone()[0] or "") == ""
+
+
+def test_action_lines_do_not_inflate_the_capture_nudge(tmp_path):
+    """Actions are a record of work, not a decision to curate — the counter's precision is the whole
+    reason it's trusted, so they must never trip it."""
+    db = tmp_path / "m.db"
+    main(["--db", str(db), "add", "-p", "/p", "-t", "fact", "-s", "seed record"])
+    _insert_log(str(db), "/p", "[changed] /repo/src/cli.py\n[ran] Commit the release — git commit -m x")
+    conn = cli.connect(str(db))
+    assert cli._uncaptured_count(conn, "/p") == 0
+
+
+def test_recall_log_searches_the_transcript_and_is_opt_in(tmp_path, capsys):
+    db = tmp_path / "m.db"
+    main(["--db", str(db), "add", "-p", "/p", "-t", "fact", "-s", "unrelated curated record"])
+    _insert_log(str(db), "/p", "[changed] /repo/src/billing.py")
+    capsys.readouterr()
+    main(["--db", str(db), "recall", "-p", "/p", "-q", "billing"])           # default: curated only
+    assert "billing.py" not in capsys.readouterr().out
+    main(["--db", str(db), "recall", "-p", "/p", "-q", "billing", "--log"])  # opt in
+    out = capsys.readouterr().out
+    assert "billing.py" in out and "log ·" in out
+
+
+def test_log_reindex_recovers_actions_from_history(tmp_path, capsys):
+    """raw was always kept in full, so action lines can be recovered for turns logged before the
+    feature existed — it doesn't start empty on a store with a long history behind it."""
+    db = tmp_path / "m.db"
+    t = _tool_turn(tmp_path, {"type": "tool_use", "name": "Edit", "input": {"file_path": "/repo/a.py"}})
+    main(["--db", str(db), "log", "--from-transcript", str(t), "-p", "/p"])
+    c = sqlite3.connect(db)                                  # simulate a pre-feature row: raw kept, no text
+    c.execute("UPDATE log SET content = ''"); c.commit(); c.close()
+    capsys.readouterr()
+    main(["--db", str(db), "log", "--reindex", "-p", "/p"])
+    assert "1 gained text" in capsys.readouterr().out
+    c = sqlite3.connect(db)
+    assert "[changed] /repo/a.py" in c.execute("SELECT content FROM log").fetchone()[0]

--- a/tests/test_v04.py
+++ b/tests/test_v04.py
@@ -721,3 +721,44 @@ def test_curate_directives_ask_for_measurements_not_conclusions(tmp_path, capsys
     capsys.readouterr()
     main(["--db", str(db), "hook", "--no-sync", "-p", "/p"])   # boot path sets agent_directive itself
     assert "MEASURED" in capsys.readouterr().out
+
+
+# --- the verdict cache: a new log turn must not re-cost a model load ------------------------------
+
+def test_semantic_verdict_survives_new_log_turns(tmp_path, monkeypatch):
+    """A new log row lands EVERY turn. A verdict about "is this snippet curated?" depends only on the
+    curated side, so turns must not invalidate it — otherwise the status bar pays a full model load
+    once per turn for the whole session (measured at ~1.2s before this cache existed)."""
+    calls = []
+    base = _concept_embedder()
+    monkeypatch.setattr(cli, "_EMBEDDER_OVERRIDE",
+                        ((lambda t: (calls.append(t), base(t))[1]), "toy"), raising=False)
+    db = tmp_path / "m.db"
+    main(["--db", str(db), "add", "-p", "/p", "-t", "fact", "-s", "office plants need weekly water"])
+    _insert_log(str(db), "/p", "We decided to migrate the billing service to Kafka.")
+
+    conn = cli.connect(str(db))
+    assert cli._uncaptured_count(conn, "/p") == 1
+    after_first = len(calls)
+    assert after_first > 0, "the semantic tier should have run for an unmatched snippet"
+
+    for i in range(3):                      # ordinary turns, no decision cue — i.e. most of a session
+        _insert_log(str(db), "/p", f"Ran the suite for pass {i} and read the output.",
+                    ts=f"2026-06-20T10:0{i}:00")
+        conn = cli.connect(str(db))
+        assert cli._uncaptured_count(conn, "/p") == 1
+    assert len(calls) == after_first, "new log turns must not re-embed an already-judged snippet"
+
+
+def test_semantic_verdict_invalidates_when_curation_changes(tmp_path, monkeypatch):
+    """The cache may not outlive the thing it's a verdict about: curating the decision clears it."""
+    monkeypatch.setattr(cli, "_EMBEDDER_OVERRIDE", (_concept_embedder(), "toy"), raising=False)
+    db = tmp_path / "m.db"
+    main(["--db", str(db), "add", "-p", "/p", "-t", "fact", "-s", "office plants need weekly water"])
+    _insert_log(str(db), "/p", "We decided to migrate the billing service to Kafka.")
+    conn = cli.connect(str(db))
+    assert cli._uncaptured_count(conn, "/p") == 1
+    main(["--db", str(db), "add", "-p", "/p", "-t", "decision",
+          "-s", "billing moves onto a streaming backbone for throughput"])   # a PARAPHRASE
+    conn = cli.connect(str(db))
+    assert cli._uncaptured_count(conn, "/p") == 0


### PR DESCRIPTION
## Summary

A CLI command that folds the records of one engrim store into another:

```
engrim merge OTHER.db [--db TARGET.db] [--project P] [--dry-run] [--verbose]
```

Today a store is one SQLite file, and the only way two copies of a project's memory meet is to pick one. Anyone running the same project's agents in more than one place — a laptop and a CI runner, two machines, two agents in parallel — ends up with two stores that each hold decisions the other lacks. `merge` folds the other store's records into the target, idempotently, preserving `ts` and provenance, so both places can keep writing and reconcile afterwards.

Issues are disabled on this repository, so this arrives as a PR rather than a proposal; if you would rather discuss the direction first, treat the description as that discussion and I will rework or withdraw.

## The concrete case behind this

We run engrim's MCP server inside GitHub Actions jobs (three agentic workflows, one project). The store is uploaded as an artifact at the end of each job and the next job seeds from the newest one — last writer wins. Two jobs that overlap each write records the other never sees, and the later upload silently drops the earlier job's. A merge at capture time (fetch the then-newest store, merge this job's into it, upload) shrinks that loss window from the length of a run to a few seconds. We had this as raw SQL against the 1.3.0 schema; the questions it forced are the design notes below, and they seemed worth settling once, next to the schema, rather than in every caller.

## Related work

I found no prior issue or PR on merging or syncing stores. `engrim sync` is the existing import path (markdown → store) and this mirrors its shape: idempotent, `--dry-run`, and the same one-line report. The roadmap's `engrim export` is complementary (records out as markdown/JSON); a merge through JSON would need the same identity and status rules anyway. The roadmap's "Record linking" is the one thing this touches sideways — see `links` below.

## Design notes

- **Identity is content, not `id`.** `memories.id` is `INTEGER PRIMARY KEY`, assigned per store, so two stores seeded from the same base hand the same id to different records. The key is `(project, ts, type, summary, coalesce(detail,''))`: `ts` is ISO to the second with a zone, and nothing rewrites a record's text (`supersede` changes only `status`). New rows get a fresh id in the target.
- **Status is monotonic.** `active` → `superseded`/`done` is the only mutation engrim makes, so a non-`active` status on either side wins and nothing is ever reactivated. That makes a merge safe in either direction and more than once (tested both ways, and converged stores are a no-op).
- **Everything else on a new row is copied verbatim**: `tags`, `links`, `source`, `origin_agent`. `links` hold source-store ids and are the one field an id change can break; this PR copies them as-is rather than inventing a remap, which is honest until "Record linking" decides what an edge is. Records written through the MCP server never set links, so in practice this is rare.
- **`memories_fts` needs nothing**: it is external-content FTS5 maintained by the `mem_ai`/`mem_au`/`mem_ad` triggers, so the plain `INSERT` and `UPDATE` keep it correct (tested: a merged record is found by `recall`).
- **`embedding`** references `memory_id`, so rows are not copied; a merged row is embedded through `_embed_row` the way `add` does, best-effort, and left for `engrim embed` when the backend is off.
- **`log`** rows dedup on the store's own `(project, msg_uuid)` index; rows without a uuid (NULLs never collide there) dedup on `(project, ts, role, content)` so a second merge adds nothing either way.
- **`engrim_meta`** is not merged; the target's values stand (it is the store that keeps running).
- **Schema**: the target is opened through `connect()`, so `_init`'s `IF NOT EXISTS` and `ALTER TABLE` guards bring an older target up first. The source is opened read-only (`mode=ro`) with no migration and no WAL switch, and columns a very old store lacks (`origin_agent`, `log.raw`) read as NULL. Its contents are never modified; reading a WAL-mode store creates empty `-wal`/`-shm` sidecars beside it, as any reader does, and the tests assert the bytes are unchanged.
- **Errors, not empty merges**: a missing path, a non-SQLite file, a SQLite file without a `memories` table, or the target itself are all `sys.exit` with a plain message, in the style of `sync`'s.
- **`--project`** defaults to *every* project in the source rather than `auto`: merging is about two copies of the same memory, not the directory you happen to be in. Stated in the help text.

## Scope notes

Additive only: `merge_store` and `cmd_merge` beside `sync`, one subparser, one README row, one test file. No existing code path changes. No new dependency; pure standard library.

## Testing

`python -m pytest` in a venv with the package installed editable and `ENGRIM_EMBED=off`: 131 passed (120 before, 11 new). The new tests cover: adds missing and skips shared; idempotent; retirement carries over and is never undone in the other direction; converged stores are a no-op both ways; `--dry-run` writes nothing; `--project` filter; a merged record is searchable; log rows dedup with and without a uuid; source bytes and rows unchanged; missing, non-SQLite, non-store and self sources rejected. Not tested: the semantic tier (the suite forces lexical), so `_embed_row` on merged rows is exercised only as the same call `add` makes.

Real-world use: the same merge, as SQL, is what we run against 1.3.0 stores captured from CI jobs; the CLI form here replaces it.

## AI disclosure

This feature was developed with Claude Code (Anthropic). The design decisions, scope choices, and review/testing direction were mine; I have reviewed the changes and stand behind them.
