### PR TITLE
feat: `engrim backup` — a consistent copy of the store while it's in use

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ the reviewed log. It does not verify that logging captured the entire session.
 | `engrim supersede`| `engrim supersede --id 12 --status superseded` | Mark a record superseded without erasing history. |
 | `engrim sync` | `engrim sync [DIR]` | Mirror markdown memories into the store (idempotent seed-once). |
 | `engrim merge` | `engrim merge OTHER.db [--dry-run]` | Fold another store's records into this one (content-keyed, idempotent; retirements carry over). |
+| `engrim backup` | `engrim backup COPY.db [--force] [--json]` | Consistent copy of the whole store via SQLite's online backup API (safe while agents hold it open). |
 
 ---
 

--- a/src/engrim/cli.py
+++ b/src/engrim/cli.py
@@ -17,6 +17,7 @@ CLI:
   projects  list tags + counts       engrim projects
   stats     row/health summary       engrim stats
   prune     purge logs + vacuum      engrim prune [--keep-days <days> | --all | --vacuum]
+  backup    consistent copy          engrim backup COPY.db [--force] [--json]   (safe while agents hold the store)
   review    coverage check           engrim review [--strict]
 
 Every record is tagged by `project` (a folder path). `--project auto` (the default) derives it
@@ -2174,6 +2175,56 @@ def cmd_merge(conn, a) -> None:
             print(f"  {action:4} {summary[:80]}")
 
 
+def cmd_backup(conn, a) -> None:
+    """Write a consistent copy of the whole store to `a.dest` through SQLite's online backup API.
+
+    Safe while another process (the MCP server, a session's hooks) still holds the store open: the
+    copy is one snapshot, never a read torn by a write in flight, and whatever sits in the -wal
+    sidecar is folded in rather than left behind. A plain file copy of a WAL-mode store gives
+    neither guarantee. The result is a complete engrim store (FTS, embeddings, log and meta
+    included) that `--db` can open directly."""
+    dest = a.dest
+    fresh = not os.path.exists(dest)
+    if not fresh:
+        mine = {os.path.realpath(a.db + ext) for ext in ("", "-wal", "-shm")}
+        if os.path.realpath(dest) in mine:
+            sys.exit("backup: destination is the store itself")
+        if not a.force:
+            sys.exit(f"backup: {dest} exists (pass --force to overwrite it)")
+    d = os.path.dirname(dest)
+    if d:
+        os.makedirs(d, exist_ok=True)
+    copy = err = None
+    try:
+        copy = sqlite3.connect(dest)
+        conn.backup(copy)
+        total = copy.execute("SELECT COUNT(*) FROM memories").fetchone()[0]
+        active = copy.execute(
+            "SELECT COUNT(*) FROM memories WHERE status = 'active'").fetchone()[0]
+    except sqlite3.DatabaseError as e:
+        err = e
+    finally:
+        if copy is not None:
+            copy.close()                # before any remove: Windows can't unlink an open file
+    if err is not None:
+        if fresh:                       # don't leave a partial file that blocks the next run
+            try:
+                os.remove(dest)
+            except OSError:
+                pass
+        sys.exit(f"backup: {err}: {dest}")
+    # The store's own owner-only stance (best-effort; no-op on Windows), sidecars included.
+    for _ext in ("", "-wal", "-shm"):
+        try:
+            os.chmod(dest + _ext, 0o600)
+        except OSError:
+            pass
+    if a.json:
+        print(json.dumps({"records": total, "active": active, "dest": dest}))
+        return
+    print(f"backed up {total} records, {active} active -> {dest}")
+
+
 # --------------------------------------------------------------------------- transcript log
 # A SEPARATE, append-only tier from `memories`. It records the raw back-and-forth so engineers
 # have a full, replayable record — but it is NEVER injected into the boot pack / context window, so
@@ -2990,6 +3041,12 @@ def build_parser() -> argparse.ArgumentParser:
     pmg.add_argument("--dry-run", action="store_true", help="show the plan, write nothing")
     pmg.add_argument("--verbose", action="store_true", help="list every add/status/skip")
     pmg.set_defaults(func=cmd_merge)
+
+    pbk = sub.add_parser("backup", help="write a consistent copy of the store (safe while it's in use)")
+    pbk.add_argument("dest", help="path for the copy (a complete engrim store)")
+    pbk.add_argument("--force", action="store_true", help="overwrite an existing file at DEST")
+    pbk.add_argument("--json", action="store_true")
+    pbk.set_defaults(func=cmd_backup)
 
     plog = sub.add_parser("log")
     plog.add_argument("-p", "--project", default="auto")

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,0 +1,167 @@
+"""Tests for `engrim backup` — a consistent copy of the store through SQLite's online backup API."""
+import json
+import os
+import shutil
+import sqlite3
+import stat
+import sys
+
+import pytest
+
+from engrim.cli import main
+
+
+def _add(db, summary, project="/p"):
+    main(["--db", str(db), "add", "-p", project, "-t", "fact", "-s", summary])
+
+
+def _rows(db):
+    c = sqlite3.connect(db)
+    rows = c.execute("SELECT project, summary, status FROM memories ORDER BY id").fetchall()
+    c.close()
+    return rows
+
+
+def test_backup_copies_every_record_and_reports_counts(tmp_path, capsys):
+    db, copy = tmp_path / "m.db", tmp_path / "copy.db"
+    _add(db, "one")
+    _add(db, "two", project="/q")
+    main(["--db", str(db), "add", "--global", "-t", "user", "-s", "three"])
+    main(["--db", str(db), "supersede", "--id", "1", "--status", "done"])
+    capsys.readouterr()
+    main(["--db", str(db), "backup", str(copy)])
+    assert capsys.readouterr().out.strip() == f"backed up 3 records, 2 active -> {copy}"
+    assert _rows(copy) == _rows(db)
+
+
+def test_backup_is_a_working_store(tmp_path, capsys):
+    """The copy carries the FTS index, meta and log with it, so it opens and searches as a store."""
+    db, copy = tmp_path / "m.db", tmp_path / "copy.db"
+    _add(db, "retrieval beats stuffing the context window")
+    main(["--db", str(db), "backup", str(copy)])
+    capsys.readouterr()
+    main(["--db", str(copy), "recall", "-p", "/p", "-q", "retrieval context"])
+    assert "retrieval beats" in capsys.readouterr().out
+
+
+def test_backup_is_independent_of_the_source(tmp_path):
+    db, copy = tmp_path / "m.db", tmp_path / "copy.db"
+    _add(db, "seed")
+    main(["--db", str(db), "backup", str(copy)])
+    _add(copy, "only in copy")
+    _add(db, "only in source")
+    assert [s for _, s, _ in _rows(db)] == ["seed", "only in source"]
+    assert [s for _, s, _ in _rows(copy)] == ["seed", "only in copy"]
+
+
+def test_backup_carries_what_a_plain_file_copy_leaves_in_the_wal(tmp_path, capsys):
+    """A committed write from a connection that stays open (the MCP server, mid-session) lives in
+    the -wal sidecar until a checkpoint. The backup folds it in; copying the .db file does not."""
+    db, copy, naive = tmp_path / "m.db", tmp_path / "copy.db", tmp_path / "naive.db"
+    _add(db, "checkpointed")
+    writer = sqlite3.connect(db)
+    writer.execute("INSERT INTO memories(ts,project,type,summary) "
+                   "VALUES('2026-01-01T00:00:00+00:00','/p','fact','still in the wal')")
+    writer.commit()
+    try:
+        shutil.copyfile(db, naive)
+        main(["--db", str(db), "backup", str(copy)])
+    finally:
+        writer.close()
+    assert "backed up 2 records, 2 active" in capsys.readouterr().out
+    assert [s for _, s, _ in _rows(copy)] == ["checkpointed", "still in the wal"]
+    assert [s for _, s, _ in _rows(naive)] == ["checkpointed"]
+
+
+def test_backup_while_another_writer_is_mid_transaction(tmp_path, capsys):
+    """An uncommitted write in flight elsewhere neither blocks the copy nor leaks into it."""
+    db, copy = tmp_path / "m.db", tmp_path / "copy.db"
+    _add(db, "committed")
+    writer = sqlite3.connect(db)
+    writer.execute(
+        "INSERT INTO memories(ts,project,type,summary) VALUES('2026-01-01T00:00:00+00:00','/p','fact','uncommitted')")
+    try:
+        main(["--db", str(db), "backup", str(copy)])
+    finally:
+        writer.rollback()
+        writer.close()
+    assert "backed up 1 records, 1 active" in capsys.readouterr().out
+    assert [s for _, s, _ in _rows(copy)] == ["committed"]
+
+
+def test_backup_refuses_to_overwrite_without_force(tmp_path, capsys):
+    db, copy = tmp_path / "m.db", tmp_path / "copy.db"
+    _add(db, "one")
+    copy.write_text("precious")
+    with pytest.raises(SystemExit):
+        main(["--db", str(db), "backup", str(copy)])
+    assert copy.read_text() == "precious"
+
+
+def test_backup_force_overwrites_a_stale_copy(tmp_path, capsys):
+    db, copy = tmp_path / "m.db", tmp_path / "copy.db"
+    _add(db, "one")
+    main(["--db", str(db), "backup", str(copy)])
+    _add(db, "two")
+    capsys.readouterr()
+    main(["--db", str(db), "backup", str(copy), "--force"])
+    assert "backed up 2 records, 2 active" in capsys.readouterr().out
+    assert [s for _, s, _ in _rows(copy)] == ["one", "two"]
+
+
+def test_backup_force_still_rejects_a_non_sqlite_file(tmp_path):
+    """A plain message, not a traceback, when --force points at something SQLite can't open."""
+    db, junk = tmp_path / "m.db", tmp_path / "junk.db"
+    _add(db, "one")
+    junk.write_text("not a database")
+    with pytest.raises(SystemExit) as e:
+        main(["--db", str(db), "backup", str(junk), "--force"])
+    assert "backup:" in str(e.value)
+
+
+def test_backup_rejects_the_store_itself_and_its_sidecars(tmp_path):
+    db = tmp_path / "m.db"
+    _add(db, "one")
+    for target in (db, tmp_path / "m.db-wal", tmp_path / "m.db-shm"):
+        with pytest.raises(SystemExit) as e:
+            main(["--db", str(db), "backup", str(target), "--force"])
+        assert "the store itself" in str(e.value)
+    assert [s for _, s, _ in _rows(db)] == ["one"]
+
+
+def test_backup_rejects_a_directory_destination_with_a_message(tmp_path):
+    db, out = tmp_path / "m.db", tmp_path / "out"
+    _add(db, "one")
+    out.mkdir()
+    for extra in ([], ["--force"]):
+        with pytest.raises(SystemExit) as e:
+            main(["--db", str(db), "backup", str(out)] + extra)
+        assert str(e.value).startswith("backup:")
+    assert out.is_dir() and not any(out.iterdir())
+
+
+def test_backup_creates_the_destination_directory(tmp_path):
+    db, copy = tmp_path / "m.db", tmp_path / "out" / "nested" / "copy.db"
+    _add(db, "one")
+    main(["--db", str(db), "backup", str(copy)])
+    assert [s for _, s, _ in _rows(copy)] == ["one"]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX file modes")
+def test_backup_is_owner_only_like_the_store(tmp_path):
+    db, copy = tmp_path / "m.db", tmp_path / "copy.db"
+    _add(db, "one")
+    main(["--db", str(db), "backup", str(copy)])
+    assert stat.S_IMODE(os.stat(copy).st_mode) == 0o600
+
+
+def test_backup_json_reports_the_copy(tmp_path, capsys):
+    """--json follows recall/list/logs: opt-in, one line, machine-shaped."""
+    db, copy = tmp_path / "m.db", tmp_path / "copy.db"
+    _add(db, "kept")
+    _add(db, "done")
+    main(["--db", str(db), "supersede", "--id", "2", "--status", "done"])
+    capsys.readouterr()
+    main(["--db", str(db), "backup", str(copy), "--json"])
+    assert json.loads(capsys.readouterr().out) == {"records": 2, "active": 1, "dest": str(copy)}
+    assert [s for _, s, _ in _rows(copy)] == ["kept", "done"]


### PR DESCRIPTION
## Summary

A CLI command that writes a consistent copy of the whole store:

```
engrim backup COPY.db [--db STORE.db] [--force] [--json]
```

A store is one SQLite file in WAL mode, and something usually holds it open: the MCP server, a session's hooks. Copying that file with `cp` (or an `upload-artifact` step) can tear across a write in flight, and leaves behind whatever is still in the `-wal` sidecar — the most recent records, until a checkpoint. `engrim backup` writes one snapshot through SQLite's online backup API instead, folds the WAL in, and reports what it copied by reading the copy back (`backed up 12 records, 9 active -> COPY.db`), so the line is also proof that the copy opens. `--json` gives the same as `{"records": N, "active": M, "dest": "COPY.db"}`, the opt-in shape `recall`/`list`/`logs` use.

Issues are disabled on this repository, so this arrives as a PR rather than a proposal; as with #8, treat the description as the discussion and I will rework or withdraw.

## The concrete case behind this

In the GitHub Agentic Workflows example (#9), a post-step captures the run's store while the MCP server container is still up and uploads it for `engrim merge` (#8) to fold in later. That step is a small `store.py capture SRC DST` script run on stdin inside the server's image, because the CLI had no way to say it. This is that operation as a command, next to `merge`, which is the other half of the same round trip.

## Related work

- #8 (`engrim merge`) is the consumer: a backup is what you merge. #9 carries the script this replaces; the example could then use the command instead.
- `engrim prune --vacuum` is the only other command that treats the file as a whole; nothing here overlaps with it.
- I found no prior issue or PR on backing up, exporting or copying a store. The roadmap's `engrim export` (records out as markdown/JSON) is a different thing: this is a byte-faithful copy of the whole store, FTS, embeddings, log and meta included.

## Design notes

- **`Connection.backup()`, not a file copy.** The source is the store `main()` already opened through `connect()`, so the copy is the same snapshot a `SELECT` would see. Python has had it since 3.7; the project floor is 3.10.
- **Refuses to overwrite** without `--force`, in `prune`'s stance on accidental data loss. Refuses the store itself, and its `-wal`/`-shm` sidecars, as a destination in any spelling `realpath` resolves.
- **A failed backup to a fresh path removes the partial file**, so the next run is not blocked by `exists`. The destination connection is closed before the remove, for Windows.
- **Owner-only copy** (0600, sidecars included), mirroring `connect()`; best-effort, no-op on Windows.
- **Destination directory created**, as `connect()` does for the store.
- **Name.** `backup`, not `capture` as in the script: "capture" already means something else in engrim (curating a decision into memory — `review`, the status bar, the capture floor).
- **Not done:** no `--project` filter. A backup is the whole store by definition; a per-project extract is `merge --project` into a fresh store, which already works.

## Scope notes

Additive only: `cmd_backup` beside `cmd_merge`, one subparser, one README row, one line in the module docstring, one test file. No existing code path changes. Standard library only.

Two sibling PRs (`engrim count`, `engrim retire`) come from the same script. Each is independent; I have checked that the three merge cleanly onto `main` in any order and the combined suite passes. `count` adds a `_store_counts` helper that `backup` could use for its two count queries; if both land I would fold that in a follow-up rather than couple the PRs.

## Testing

`python -m pytest` in a venv with the package installed editable and `ENGRIM_EMBED=off`, Python 3.13, macOS: 210 passed (197 before, 13 new). The new tests cover: every record across projects and the global layer copied, counts reported; the copy is a working store (`recall` finds a record in it); source and copy are independent afterwards; a committed row that is still in the source's WAL (open writer, no checkpoint) is in the backup and absent from a `shutil.copyfile` of the same file; an uncommitted write elsewhere neither blocks the copy nor leaks into it; an existing file is refused and left intact; `--force` overwrites; `--force` onto a non-SQLite file exits with a message, not a traceback; the store and its sidecars are rejected as destinations; a directory destination is rejected with a message; the destination directory is created; the copy is 0600 (POSIX only); the `--json` object. Also `engrim --help`, `engrim backup --help`, and a piped run by hand. Not run locally: Windows (CI covers it; the chmod is best-effort as in `connect()`).

Real-world use: the same operation, as the script in #9, is what our CI runs after every agent job.

## AI disclosure

This feature was developed with Claude Code (Anthropic). The design decisions, scope choices, and review/testing direction were mine; I have reviewed the changes and stand behind them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
