### PR TITLE
feat: `engrim count` — one line for the whole store

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ the reviewed log. It does not verify that logging captured the entire session.
 | `engrim serve` | `engrim serve --mcp` | Start stdio MCP server for agent integrations. |
 | `engrim review` | `engrim review [--strict]` | "Safe to clear" coverage check: scans logs for uncurated decisions (`--strict` exits 2 if uncaptured). |
 | `engrim prune` | `engrim prune [--keep-days <N> \| --all \| --vacuum]` | Purge old transcript logs and VACUUM the SQLite DB (opt-in retention; off by default). |
+| `engrim count` | `engrim count [--json]` | One line for the whole store, `N records, M active` (for scripts and CI logs; `--json` for machines). |
 | `engrim list` | `engrim list [-k 20] [--tag auth]` | List recent memories for the current project (supports `--tag`). |
 | `engrim supersede`| `engrim supersede --id 12 --status superseded` | Mark a record superseded without erasing history. |
 | `engrim sync` | `engrim sync [DIR]` | Mirror markdown memories into the store (idempotent seed-once). |

--- a/src/engrim/cli.py
+++ b/src/engrim/cli.py
@@ -16,6 +16,7 @@ CLI:
   supersede mark status by id        engrim supersede --id 12 --status superseded
   projects  list tags + counts       engrim projects
   stats     row/health summary       engrim stats
+  count     one-line store count     engrim count [--json]  ("N records, M active", whole store)
   prune     purge logs + vacuum      engrim prune [--keep-days <days> | --all | --vacuum]
   review    coverage check           engrim review [--strict]
 
@@ -1173,6 +1174,25 @@ def cmd_projects(conn, a) -> None:
         print(f"{r['n']:4d} ({r['active']} active)  last {r['last'][:16]}  {r['project']}")
     if not rows:
         print("(empty store)")
+
+
+def _store_counts(conn) -> tuple[int, int]:
+    """(records, active records) across the whole store — every project and the global layer."""
+    total = conn.execute("SELECT count(*) FROM memories").fetchone()[0]
+    active = conn.execute("SELECT count(*) FROM memories WHERE status = 'active'").fetchone()[0]
+    return total, active
+
+
+def cmd_count(conn, a) -> None:
+    """One line for the whole store: `N records, M active`. The number a script wants — a CI step
+    logging what it seeded or captured, a job watching a store grow — with no project resolution
+    (`stats` derives one from the cwd and prints its context economics) and one line rather than
+    one per project (`projects`)."""
+    total, active = _store_counts(conn)
+    if a.json:
+        print(json.dumps({"records": total, "active": active}))
+        return
+    print(f"{total} records, {active} active")
 
 
 def _est_tokens(chars: int) -> int:
@@ -3054,6 +3074,9 @@ def build_parser() -> argparse.ArgumentParser:
     ppr.set_defaults(func=cmd_prune)
 
     sub.add_parser("projects").set_defaults(func=cmd_projects)
+    pct = sub.add_parser("count", help="one line for the whole store: N records, M active")
+    pct.add_argument("--json", action="store_true")
+    pct.set_defaults(func=cmd_count)
 
     pst = sub.add_parser("stats")
     pst.add_argument("-p", "--project", default="auto")

--- a/tests/test_count.py
+++ b/tests/test_count.py
@@ -1,0 +1,56 @@
+"""Tests for `engrim count` — one line, whole store: `N records, M active`."""
+import json
+
+from engrim.cli import main
+
+
+def _add(db, summary, project="/p", type_="fact"):
+    main(["--db", str(db), "add", "-p", project, "-t", type_, "-s", summary])
+
+
+def test_count_empty_store(tmp_path, capsys):
+    main(["--db", str(tmp_path / "m.db"), "count"])
+    assert capsys.readouterr().out.strip() == "0 records, 0 active"
+
+
+def test_count_spans_every_project_and_the_global_layer(tmp_path, capsys):
+    db = tmp_path / "m.db"
+    _add(db, "one", project="/p")
+    _add(db, "two", project="/q")
+    main(["--db", str(db), "add", "--global", "-t", "user", "-s", "three"])
+    capsys.readouterr()
+    main(["--db", str(db), "count"])
+    assert capsys.readouterr().out.strip() == "3 records, 3 active"
+
+
+def test_count_separates_active_from_retired(tmp_path, capsys):
+    db = tmp_path / "m.db"
+    _add(db, "kept")
+    _add(db, "superseded")
+    _add(db, "done")
+    main(["--db", str(db), "supersede", "--id", "2", "--status", "superseded"])
+    main(["--db", str(db), "supersede", "--id", "3", "--status", "done"])
+    capsys.readouterr()
+    main(["--db", str(db), "count"])
+    assert capsys.readouterr().out.strip() == "3 records, 1 active"
+
+
+def test_count_needs_no_project_and_prints_exactly_one_line(tmp_path, capsys, monkeypatch):
+    """No cwd-derived project tag is involved, so the line is the same from any directory."""
+    db = tmp_path / "m.db"
+    _add(db, "one")
+    monkeypatch.chdir(tmp_path)
+    capsys.readouterr()
+    main(["--db", str(db), "count"])
+    assert capsys.readouterr().out == "1 records, 1 active\n"
+
+
+def test_count_json_is_one_object(tmp_path, capsys):
+    """--json follows recall/list/logs: opt-in, one line, machine-shaped."""
+    db = tmp_path / "m.db"
+    _add(db, "kept")
+    _add(db, "done")
+    main(["--db", str(db), "supersede", "--id", "2", "--status", "done"])
+    capsys.readouterr()
+    main(["--db", str(db), "count", "--json"])
+    assert json.loads(capsys.readouterr().out) == {"records": 2, "active": 1}


### PR DESCRIPTION
## Summary

One line for the whole store:

```
engrim count [--db STORE.db] [--json]
```

Prints `N records, M active` across every project plus the global layer, or `{"records": N, "active": M}` with `--json`. It is the number a script wants: a CI step logging what it seeded or captured, a job watching a store grow, a health check.

Issues are disabled on this repository, so this arrives as a PR rather than a proposal; as with #8, treat the description as the discussion and I will rework or withdraw.

## Why not `stats` or `projects`

`stats` resolves a project from the cwd (git root, then cwd) and prints by-type, by-status and that project's context economics over several lines; `projects` prints one line per project. Neither gives "how big is this store" as one greppable line with no project involved, and neither has `--json`. The reference script in #9 (`store.py count DB`) exists for that reason.

## Related work

- #9 carries the script this replaces. #8 (`merge`) and the sibling `backup` PR print `N records, M active` in their own reports, so the vocabulary matches.
- I found no prior issue or PR on a count command or a machine-readable stats output.

## Design notes

- **Whole store, no `--project`.** `projects` already gives per-project counts, and "the store" is unambiguous. A `-p` with the usual `auto` default is an easy follow-up, but it would change what the bare command means, so it is left out.
- **`--json`** follows the existing opt-in flag on `recall`/`list`/`context`/`logs`: `json.dumps` on one line, human text by default.
- **`_store_counts(conn)`** keeps the two queries in one place; `stats` and `projects` compute their own shapes and are untouched.

## Scope notes

Additive only: `_store_counts` and `cmd_count` beside `cmd_projects`, one subparser, one README row, one line in the module docstring, one test file. No existing code path changes. Standard library only.

Two sibling PRs (`engrim backup`, `engrim retire`) come from the same script. Each is independent; I have checked that the three merge cleanly onto `main` in any order and the combined suite passes.

## Testing

`python -m pytest` in a venv with the package installed editable and `ENGRIM_EMBED=off`, Python 3.13, macOS: 202 passed (197 before, 5 new). The new tests cover: an empty store; counts span projects and the global layer; active is separated from superseded and done; exactly one line, from any cwd; the `--json` object. Also `engrim --help` and `engrim count --help`.

## AI disclosure

This feature was developed with Claude Code (Anthropic). The design decisions, scope choices, and review/testing direction were mine; I have reviewed the changes and stand behind them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
