### PR TITLE
feat: `engrim retire` — mark the active resume-pointer(s) done

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ the reviewed log. It does not verify that logging captured the entire session.
 | `engrim prune` | `engrim prune [--keep-days <N> \| --all \| --vacuum]` | Purge old transcript logs and VACUUM the SQLite DB (opt-in retention; off by default). |
 | `engrim list` | `engrim list [-k 20] [--tag auth]` | List recent memories for the current project (supports `--tag`). |
 | `engrim supersede`| `engrim supersede --id 12 --status superseded` | Mark a record superseded without erasing history. |
+| `engrim retire` | `engrim retire [--all] [--dry-run] [--json]` | Mark the active `resume-pointer` record(s) done once their work is finished (never erases). |
 | `engrim sync` | `engrim sync [DIR]` | Mirror markdown memories into the store (idempotent seed-once). |
 | `engrim merge` | `engrim merge OTHER.db [--dry-run]` | Fold another store's records into this one (content-keyed, idempotent; retirements carry over). |
 
@@ -220,7 +221,7 @@ the reviewed log. It does not verify that logging captured the entire session.
 ## 8. Continue-As-Clear Workflow
 
 1. **Capture as you work**: Whenever a major decision or architectural rule is made, it needs to be saved to memory. The AI agent will often do this automatically via the `engrim_add` tool, but you can also manually intervene by running `engrim add` yourself.
-2. **Use `resume-pointer`**: Before ending a session or clearing, add a record tagged `resume-pointer` describing the immediate next task. The newest pointer is pinned under `[▶ RESUME HERE]` at the top of the next session's boot pack.
+2. **Use `resume-pointer`**: Before ending a session or clearing, add a record tagged `resume-pointer` describing the immediate next task. The newest pointer is pinned under `[▶ RESUME HERE]` at the top of the next session's boot pack. When that work is done, `engrim retire` marks the pointer(s) `done` so a finished task never leads a later pack.
 3. **Verify with `engrim review`**: Check that all recent decisions are captured.
 4. **Clear freely (`/clear`)**: The session window is wiped clean; `engrim` automatically re-injects the active memory pack on the next prompt or invocation.
 

--- a/src/engrim/cli.py
+++ b/src/engrim/cli.py
@@ -14,6 +14,7 @@ CLI:
   setup     wire the hook + notes     engrim setup           (white-glove one-shot install)
   list      recent for a project     engrim list [-k 20] [--tag auth]
   supersede mark status by id        engrim supersede --id 12 --status superseded
+  retire    close resume-pointers    engrim retire [-p P | --all] [--dry-run] [--json]
   projects  list tags + counts       engrim projects
   stats     row/health summary       engrim stats
   prune     purge logs + vacuum      engrim prune [--keep-days <days> | --all | --vacuum]
@@ -1162,6 +1163,46 @@ def cmd_supersede(conn, a) -> None:
     n = conn.execute("UPDATE memories SET status=? WHERE id=?", (a.status, a.id)).rowcount
     conn.commit()
     print(f"updated {n} row(s): #{a.id} -> {a.status}")
+
+
+def cmd_retire(conn, a) -> None:
+    """Mark every active resume-pointer `done` — the records the boot pack would pin under
+    [▶ RESUME HERE], selected by the same predicate (`_is_resume`) so the two can't disagree.
+
+    A pointer says where one session left off. Once that work is finished, or the store moves
+    somewhere that working tree no longer exists (a CI runner folding a run's store into the
+    shared one), an active pointer would lead the next session's pack as if it were its own.
+    engrim never retires one on its own, since it can't know the work is done; this is the hand
+    that does. `done` is the same monotonic move `supersede` makes: nothing is erased, the record
+    stays readable with --include-stale, and `merge` carries the retirement to other copies.
+    Scoped to exactly one project like every other write (`prune`, `embed`), so a pointer written
+    to the global layer — which the pack pins in every project — takes `-p __global__` or `--all`."""
+    if a.all:
+        project = None
+        rows = conn.execute(
+            "SELECT * FROM memories WHERE status = 'active' ORDER BY id").fetchall()
+        scope = "all projects"
+    else:
+        project = _resolve_project(a.project)
+        rows = conn.execute(
+            "SELECT * FROM memories WHERE project = ? AND status = 'active' ORDER BY id",
+            (project,)).fetchall()
+        scope = f"project={project}"
+    pointers = [r for r in rows if _is_resume(r)]
+    if pointers and not a.dry_run:
+        clause, ids = _in_clause([r["id"] for r in pointers], "id")
+        conn.execute(f"UPDATE memories SET status = 'done' WHERE {clause}", ids)
+        conn.commit()
+    if a.json:
+        status = "active" if a.dry_run else "done"     # the rows were read before the update
+        print(json.dumps({"retired": len(pointers), "dry_run": a.dry_run, "project": project,
+                          "pointers": [{**dict(r), "status": status} for r in pointers]},
+                         default=str))
+        return
+    head = "DRY-RUN — no changes written; would retire" if a.dry_run else "retired"
+    print(f"{head} {len(pointers)} resume-pointer(s) · {scope}")
+    for r in pointers:
+        print(f"  #{r['id']} {r['ts'][:16]}  {(r['summary'] or '')[:80]}")
 
 
 def cmd_projects(conn, a) -> None:
@@ -2923,6 +2964,14 @@ def build_parser() -> argparse.ArgumentParser:
     ps.add_argument("--id", type=int, required=True)
     ps.add_argument("--status", default="superseded")
     ps.set_defaults(func=cmd_supersede)
+
+    prt = sub.add_parser("retire", help="mark the active resume-pointer(s) done (this project, or --all)")
+    prt.add_argument("-p", "--project", default="auto",
+                     help="scope to a project (default: auto; use --all for every project)")
+    prt.add_argument("--all", action="store_true", help="retire pointers across all projects")
+    prt.add_argument("--dry-run", action="store_true", help="list what would be retired, write nothing")
+    prt.add_argument("--json", action="store_true")
+    prt.set_defaults(func=cmd_retire)
 
     pse = sub.add_parser("setup", help="wire engrim into agent environments (Antigravity, Claude, Cursor)")
     pse.add_argument("--agy", "--antigravity", dest="agy", action="store_true",

--- a/tests/test_retire.py
+++ b/tests/test_retire.py
@@ -1,0 +1,138 @@
+"""Tests for `engrim retire` — marking the active resume-pointer(s) done."""
+import json
+import sqlite3
+
+from engrim.cli import main
+
+
+def _add(db, summary, project="/p", tags=None, type_="state"):
+    args = ["--db", str(db), "add", "-p", project, "-t", type_, "-s", summary]
+    if tags:
+        args += ["--tags", tags]
+    main(args)
+
+
+def _status(db):
+    c = sqlite3.connect(db)
+    rows = c.execute("SELECT summary, status FROM memories ORDER BY id").fetchall()
+    c.close()
+    return dict(rows)
+
+
+def test_retire_marks_every_active_pointer_done_and_nothing_else(tmp_path, capsys):
+    db = tmp_path / "m.db"
+    _add(db, "old pointer", tags="resume-pointer")
+    _add(db, "we chose postgres for billing", type_="decision")
+    _add(db, "new pointer", tags="wip,resume-pointer")
+    capsys.readouterr()
+    main(["--db", str(db), "retire", "-p", "/p"])
+    out = capsys.readouterr().out
+    assert out.startswith("retired 2 resume-pointer(s) · project=/p\n")
+    assert "#1 " in out and "old pointer" in out and "#3 " in out and "new pointer" in out
+    assert _status(db) == {"old pointer": "done", "we chose postgres for billing": "active",
+                           "new pointer": "done"}
+
+
+def test_retire_clears_the_resume_section_of_the_boot_pack(tmp_path, capsys):
+    db = tmp_path / "m.db"
+    _add(db, "pick up at discovery pass three", tags="resume-pointer")
+    main(["--db", str(db), "context", "-p", "/p"])
+    assert "[▶ RESUME HERE]" in capsys.readouterr().out
+    main(["--db", str(db), "retire", "-p", "/p"])
+    capsys.readouterr()
+    main(["--db", str(db), "context", "-p", "/p"])
+    assert "[▶ RESUME HERE]" not in capsys.readouterr().out
+
+
+def test_retire_is_idempotent(tmp_path, capsys):
+    db = tmp_path / "m.db"
+    _add(db, "pointer", tags="resume-pointer")
+    main(["--db", str(db), "retire", "-p", "/p"])
+    capsys.readouterr()
+    main(["--db", str(db), "retire", "-p", "/p"])
+    assert capsys.readouterr().out == "retired 0 resume-pointer(s) · project=/p\n"
+
+
+def test_retire_is_scoped_to_the_project_unless_all(tmp_path, capsys):
+    db = tmp_path / "m.db"
+    _add(db, "p pointer", project="/p", tags="resume-pointer")
+    _add(db, "q pointer", project="/q", tags="resume-pointer")
+    main(["--db", str(db), "retire", "-p", "/p"])
+    assert _status(db) == {"p pointer": "done", "q pointer": "active"}
+    capsys.readouterr()
+    main(["--db", str(db), "retire", "--all"])
+    assert capsys.readouterr().out.startswith("retired 1 resume-pointer(s) · all projects\n")
+    assert _status(db) == {"p pointer": "done", "q pointer": "done"}
+
+
+def test_retire_dry_run_lists_but_writes_nothing(tmp_path, capsys):
+    db = tmp_path / "m.db"
+    _add(db, "pointer", tags="resume-pointer")
+    capsys.readouterr()
+    main(["--db", str(db), "retire", "-p", "/p", "--dry-run"])
+    out = capsys.readouterr().out
+    assert "DRY-RUN" in out and "would retire 1 resume-pointer(s)" in out and "pointer" in out
+    assert _status(db) == {"pointer": "active"}
+
+
+def test_retire_matches_the_tag_not_the_words(tmp_path):
+    """Only a record TAGGED resume-pointer is a pointer — the same test the boot pack applies. A
+    record that merely mentions the phrase, or carries a tag that contains it, is not."""
+    db = tmp_path / "m.db"
+    _add(db, "decided to add a resume-pointer before every clear", type_="decision")
+    _add(db, "tagged with a superstring", tags="resume-pointers")
+    _add(db, "real pointer", tags="resume-pointer")
+    main(["--db", str(db), "retire", "-p", "/p"])
+    assert _status(db) == {"decided to add a resume-pointer before every clear": "active",
+                           "tagged with a superstring": "active", "real pointer": "done"}
+
+
+def test_retired_pointer_stays_readable_and_ready_to_merge(tmp_path, capsys):
+    """Retirement is the same monotonic move as supersede: nothing erased, visible with
+    --include-stale, and `merge` carries it to another copy of the store."""
+    db, other = tmp_path / "m.db", tmp_path / "other.db"
+    _add(db, "pointer", tags="resume-pointer")
+    _add(other, "pointer", tags="resume-pointer")
+    c = sqlite3.connect(db)
+    ts = c.execute("SELECT ts FROM memories").fetchone()[0]
+    c.close()
+    c = sqlite3.connect(other)
+    c.execute("UPDATE memories SET ts = ?", (ts,))     # the same record in two copies of the store
+    c.commit()
+    c.close()
+    main(["--db", str(db), "retire", "-p", "/p"])
+    capsys.readouterr()
+    main(["--db", str(db), "list", "-p", "/p", "--include-stale"])
+    assert "[state/done]" in capsys.readouterr().out
+    main(["--db", str(other), "merge", str(db)])
+    assert _status(other) == {"pointer": "done"}
+
+
+def test_retire_leaves_the_global_layer_to_all_or_an_explicit_tag(tmp_path, capsys):
+    """Writes are project-exact, like prune and embed: a pointer in the global layer (pinned in every
+    project's pack) is not touched by a project-scoped retire, and is by --all or -p __global__."""
+    db = tmp_path / "m.db"
+    main(["--db", str(db), "add", "--global", "-t", "state", "-s", "global pointer", "--tags", "resume-pointer"])
+    _add(db, "p pointer", tags="resume-pointer")
+    main(["--db", str(db), "retire", "-p", "/p"])
+    assert _status(db) == {"global pointer": "active", "p pointer": "done"}
+    main(["--db", str(db), "retire", "-p", "__global__"])
+    assert _status(db) == {"global pointer": "done", "p pointer": "done"}
+
+
+def test_retire_json_reports_what_it_did_or_would_do(tmp_path, capsys):
+    """--json follows recall/list/logs: opt-in, one line, the pointers as full rows."""
+    db = tmp_path / "m.db"
+    _add(db, "pointer", tags="resume-pointer")
+    _add(db, "we chose postgres for billing", type_="decision")
+    capsys.readouterr()
+    main(["--db", str(db), "retire", "-p", "/p", "--dry-run", "--json"])
+    out = json.loads(capsys.readouterr().out)
+    assert (out["retired"], out["dry_run"], out["project"]) == (1, True, "/p")
+    assert [(p["id"], p["summary"], p["status"]) for p in out["pointers"]] == [(1, "pointer", "active")]
+    assert _status(db) == {"pointer": "active", "we chose postgres for billing": "active"}
+    main(["--db", str(db), "retire", "--all", "--json"])
+    out = json.loads(capsys.readouterr().out)
+    assert (out["retired"], out["dry_run"], out["project"]) == (1, False, None)
+    assert out["pointers"][0]["status"] == "done"
+    assert _status(db) == {"pointer": "done", "we chose postgres for billing": "active"}


### PR DESCRIPTION
## Summary

A CLI command that closes the session-resume cursor(s):

```
engrim retire [-p PROJECT | --all] [--dry-run] [--json]
```

A record tagged `resume-pointer` says where one session left off, and the boot pack pins the newest active one under `[▶ RESUME HERE]` (README §8). Nothing retires it: engrim cannot know when the work it describes is done, so today a pointer stays active until someone finds its id and runs `supersede --id N --status done`. `engrim retire` is that operation by name: every active pointer in the project becomes `done`, and each is listed as it goes.

Issues are disabled on this repository, so this arrives as a PR rather than a proposal; as with #8, treat the description as the discussion and I will rework or withdraw.

## The concrete case behind this

In CI (#9), a run's store is merged into the shared one after the job. Its pointer describes a working tree that no longer exists; left active, the next run boots as if it were resuming that work. The merge workflow retires pointers with a script (`store.py retire`); this is that as a command. It is equally the local case: the task is finished, so clear the pointer before the next session.

## Related work

- #8 (`merge`) established that retirement is monotonic and carries across copies; this makes the same move (`done`, nothing erased), and a test shows a retired pointer merges as `done` into another copy of the store.
- #9 carries the script this replaces.
- I found no prior issue or PR on retiring or expiring pointers.

## Design notes

- **Same predicate as the pack.** Pointers are selected with `_is_resume`, the JSON tag membership `_boot_pack` pins with, not a `LIKE '%resume-pointer%'` over the tags column (which the script did, and which also matches a record that merely mentions the phrase, or a `resume-pointers` tag). Tested both ways.
- **Every active pointer, not just the newest.** The pack pins the newest, but older ones are still active `state` records; once the work is done they are all stale.
- **Project-exact scope**, like the other writes (`prune`, `embed`): `-p` defaults to `auto`, `--all` spans the store. One consequence, disclosed and tested: a pointer written with `--global` is pinned in every project's pack (reads span project + global), but `retire -p P` does not touch it; `-p __global__` or `--all` does. I chose write-exactness so a project-scoped command never edits the global layer as a side effect; happy to flip it if you would rather `retire` mirror what the pack shows.
- **`done`, not `superseded`.** The pointer was fulfilled or abandoned, not replaced. No `--status` option; `supersede` has that.
- **Output.** `retired 2 resume-pointer(s) · project=/p`, then one line per pointer. `--dry-run` prefixes `DRY-RUN — no changes written; would retire`, in `merge`'s style. `--json` follows the opt-in flag on `recall`/`list`/`logs`: `{"retired": N, "dry_run": bool, "project": "/p" | null (for --all), "pointers": [full rows]}`.
- **README:** one row in the CLI table and one sentence in §8 after the pointer step.

## Scope notes

Additive only: `cmd_retire` beside `cmd_supersede`, one subparser, README, one line in the module docstring, one test file. No existing code path changes. Standard library only.

Two sibling PRs (`engrim backup`, `engrim count`) come from the same script. Each is independent; I have checked that the three merge cleanly onto `main` in any order and the combined suite passes.

## Testing

`python -m pytest` in a venv with the package installed editable and `ENGRIM_EMBED=off`, Python 3.13, macOS: 206 passed (197 before, 9 new). The new tests cover: every active pointer retired and nothing else; the pack no longer shows `[▶ RESUME HERE]`; idempotent; project-scoped unless `--all`; `--dry-run` lists and writes nothing; the tag, not the words; a retired pointer stays readable with `--include-stale` and merges as `done` into another copy; the global layer needs `--all` or `-p __global__`; the `--json` shape for both a dry run and a write. Also `engrim --help` and `engrim retire --help`.

Real-world use: the same operation, as the script in #9, is what our merge workflow runs on every folded store.

## AI disclosure

This feature was developed with Claude Code (Anthropic). The design decisions, scope choices, and review/testing direction were mine; I have reviewed the changes and stand behind them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
