### PR TITLE
feat: `engrim project` — one project's counts; `projects` stays the every-project list

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@ the reviewed log. It does not verify that logging captured the entire session.
 | `engrim review` | `engrim review [--strict]` | "Safe to clear" coverage check: scans logs for uncurated decisions (`--strict` exits 2 if uncaptured). |
 | `engrim prune` | `engrim prune [--keep-days <N> \| --all \| --vacuum]` | Purge old transcript logs and VACUUM the SQLite DB (opt-in retention; off by default). |
 | `engrim list` | `engrim list [-k 20] [--tag auth]` | List recent memories for the current project (supports `--tag`). |
+| `engrim project` | `engrim project [-p PROJECT \| --global \| --all] [--json]` | Records, active count and last write for one project tag (the current one by default), or every tag with `--all`. |
+| `engrim projects` | `engrim projects [--json]` | Every project's counts — the same as `engrim project --all`. |
 | `engrim supersede`| `engrim supersede --id 12 --status superseded` | Mark a record superseded without erasing history. |
 | `engrim sync` | `engrim sync [DIR]` | Mirror markdown memories into the store (idempotent seed-once). |
 | `engrim merge` | `engrim merge OTHER.db [--dry-run]` | Fold another store's records into this one (content-keyed, idempotent; retirements carry over). |

--- a/src/engrim/cli.py
+++ b/src/engrim/cli.py
@@ -14,7 +14,8 @@ CLI:
   setup     wire the hook + notes     engrim setup           (white-glove one-shot install)
   list      recent for a project     engrim list [-k 20] [--tag auth]
   supersede mark status by id        engrim supersede --id 12 --status superseded
-  projects  list tags + counts       engrim projects
+  project   tag + counts             engrim project [-p P | --global | --all] [--json]
+  projects  list tags + counts       engrim projects [--json]   (= project --all)
   stats     row/health summary       engrim stats
   prune     purge logs + vacuum      engrim prune [--keep-days <days> | --all | --vacuum]
   review    coverage check           engrim review [--strict]
@@ -1164,15 +1165,29 @@ def cmd_supersede(conn, a) -> None:
     print(f"updated {n} row(s): #{a.id} -> {a.status}")
 
 
-def cmd_projects(conn, a) -> None:
+def cmd_project(conn, a) -> None:
+    """One line per project tag: records, active records, last write. Scoped like every other
+    read — the cwd's project by default, `-p` for another, `--global` for the user-layer — with
+    `--all` for every project in the store. `engrim projects` is that last form by name (its
+    subparser sets all=True), so the plural keeps listing the whole store as it always has.
+    `--json` gives the same rows as a list of objects."""
+    if a.all:
+        where, params, scope = "", (), "all projects"
+    else:
+        project = GLOBAL_PROJECT if a.globl else _resolve_project(a.project)
+        where, params, scope = "WHERE project = ? ", (project,), f"project={project}"
     rows = conn.execute(
         "SELECT project, COUNT(*) n, SUM(status='active') active, MAX(ts) last "
-        "FROM memories GROUP BY project ORDER BY last DESC"
+        f"FROM memories {where}GROUP BY project ORDER BY last DESC", params
     ).fetchall()
+    if a.json:
+        print(json.dumps([{"project": r["project"], "records": r["n"], "active": r["active"],
+                           "last": r["last"]} for r in rows]))
+        return
     for r in rows:
         print(f"{r['n']:4d} ({r['active']} active)  last {r['last'][:16]}  {r['project']}")
     if not rows:
-        print("(empty store)")
+        print("(empty store)" if a.all else f"(no records for {scope})")
 
 
 def _est_tokens(chars: int) -> int:
@@ -3053,7 +3068,19 @@ def build_parser() -> argparse.ArgumentParser:
                      help="display how many rows would be purged without modifying the database")
     ppr.set_defaults(func=cmd_prune)
 
-    sub.add_parser("projects").set_defaults(func=cmd_projects)
+    ppj = sub.add_parser("project", help="records, active and last write for a project tag")
+    scope = ppj.add_mutually_exclusive_group()
+    scope.add_argument("-p", "--project", default="auto",
+                       help="one project tag (default: auto, the current directory's)")
+    scope.add_argument("-g", "--global", dest="globl", action="store_true",
+                       help="the global user-layer only")
+    scope.add_argument("--all", action="store_true", help="every project in the store")
+    ppj.add_argument("--json", action="store_true")
+    ppj.set_defaults(func=cmd_project)
+
+    ppjs = sub.add_parser("projects", help="every project's records, active and last write (= project --all)")
+    ppjs.add_argument("--json", action="store_true")
+    ppjs.set_defaults(func=cmd_project, project=None, globl=False, all=True)
 
     pst = sub.add_parser("stats")
     pst.add_argument("-p", "--project", default="auto")

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,0 +1,95 @@
+"""Tests for `engrim project` — one project tag's counts, scoped like every other read — and
+`engrim projects`, the every-project alias."""
+import json
+
+import pytest
+
+from engrim.cli import main
+
+
+def _add(db, summary, project="/p", type_="fact"):
+    main(["--db", str(db), "add", "-p", project, "-t", type_, "-s", summary])
+
+
+@pytest.fixture
+def store(tmp_path):
+    """/p: 2 records (1 active); /q: 1; global: 1."""
+    db = tmp_path / "m.db"
+    _add(db, "p one")
+    _add(db, "p two")
+    main(["--db", str(db), "supersede", "--id", "2", "--status", "done"])
+    _add(db, "q one", project="/q")
+    main(["--db", str(db), "add", "--global", "-t", "user", "-s", "me"])
+    return db
+
+
+def _lines(out):
+    return [" ".join(l.split()) for l in out.strip().splitlines()]
+
+
+def test_project_all_lists_every_project(store, capsys):
+    main(["--db", str(store), "project", "--all"])
+    lines = _lines(capsys.readouterr().out)
+    assert len(lines) == 3
+    assert any(l.startswith("2 (1 active)") and l.endswith("/p") for l in lines)
+    assert any(l.startswith("1 (1 active)") and l.endswith("/q") for l in lines)
+    assert any(l.endswith("__global__") for l in lines)
+
+
+def test_project_defaults_to_the_current_project(store, capsys, monkeypatch):
+    """Same precedence as every other read: explicit -p, then $ENGRIM_PROJECT, then the cwd."""
+    monkeypatch.setenv("ENGRIM_PROJECT", "/q")
+    main(["--db", str(store), "project"])
+    lines = _lines(capsys.readouterr().out)
+    assert len(lines) == 1 and lines[0].startswith("1 (1 active) last 20") and lines[0].endswith(" /q")
+    main(["--db", str(store), "project", "-p", "/p"])
+    lines = _lines(capsys.readouterr().out)
+    assert len(lines) == 1 and lines[0].startswith("2 (1 active)") and lines[0].endswith(" /p")
+
+
+def test_project_global_is_the_user_layer_only(store, capsys):
+    main(["--db", str(store), "project", "--global"])
+    lines = _lines(capsys.readouterr().out)
+    assert len(lines) == 1 and lines[0].endswith("__global__")
+
+
+def test_project_scopes_are_mutually_exclusive(store):
+    with pytest.raises(SystemExit):
+        main(["--db", str(store), "project", "-p", "/p", "--all"])
+    with pytest.raises(SystemExit):
+        main(["--db", str(store), "project", "--global", "--all"])
+
+
+def test_project_json_is_a_list_of_rows(store, capsys):
+    main(["--db", str(store), "project", "-p", "/p", "--json"])
+    rows = json.loads(capsys.readouterr().out)
+    assert len(rows) == 1
+    assert {k: rows[0][k] for k in ("project", "records", "active")} == {"project": "/p", "records": 2, "active": 1}
+    assert rows[0]["last"].startswith("20")
+    main(["--db", str(store), "project", "--all", "--json"])
+    rows = json.loads(capsys.readouterr().out)
+    assert sorted(r["project"] for r in rows) == ["/p", "/q", "__global__"]
+
+
+def test_project_empty_scopes_say_so(tmp_path, capsys):
+    db = tmp_path / "m.db"
+    main(["--db", str(db), "project", "--all"])
+    assert capsys.readouterr().out.strip() == "(empty store)"
+    main(["--db", str(db), "project", "-p", "/nowhere"])
+    assert capsys.readouterr().out.strip() == "(no records for project=/nowhere)"
+    main(["--db", str(db), "project", "-p", "/nowhere", "--json"])
+    assert json.loads(capsys.readouterr().out) == []
+
+
+def test_projects_is_project_all(store, capsys):
+    """The plural keeps listing the whole store, text and JSON alike, and takes no scope."""
+    main(["--db", str(store), "projects"])
+    plural = capsys.readouterr().out
+    main(["--db", str(store), "project", "--all"])
+    assert plural == capsys.readouterr().out and len(_lines(plural)) == 3
+    main(["--db", str(store), "projects", "--json"])
+    plural = capsys.readouterr().out
+    main(["--db", str(store), "project", "--all", "--json"])
+    assert plural == capsys.readouterr().out and len(json.loads(plural)) == 3
+    with pytest.raises(SystemExit):
+        main(["--db", str(store), "projects", "-p", "/p"])


### PR DESCRIPTION
## Summary

`engrim projects` lists every project in the store; there was no way to ask for one, and no shape a script can read. This adds the singular, scoped like every other read, and gives both a machine-readable form:

```
engrim project  [-p PROJECT | --global | --all] [--json]
engrim projects [--json]                                  # = engrim project --all
```

`project` prints one line — records, active records, last write — for the current directory's project by default, another tag with `-p`, the global user-layer with `--global`, or every tag with `--all`. `projects` keeps exactly its current meaning: it is a second subparser whose defaults are `project --all`, so nothing that exists changes. `--json` on either prints the rows as a list of `{"project", "records", "active", "last"}` objects.

Issues are disabled on this repository, so this arrives as a PR rather than a proposal; as with #8, treat the description as the discussion and I will rework or withdraw.

## The concrete case behind this

Scripts around the CI example (#9) want a store's size as a number: what a step seeded or captured, how a project's memory grows. I first proposed a separate `engrim count` (#11) for that and closed it — `projects` already computes exactly those numbers and only lacked a way to ask for one project and a shape a script can read. This is the smaller change.

## Related work

- #11 (closed) is the alternative this replaces. #10 (`backup`) merges cleanly alongside this. #12 (`retire`) touches the two lines adjacent to the ones this edits (the docstring table row above `projects` and the function before it), so git reports a trivial conflict between the two; I will rebase whichever lands second.
- `stats` prints whole-store totals by type and status plus one project's context economics, and has no `--json`; untouched here.
- I found no prior issue or PR on scoping or JSON output for `projects`.

## Design notes

- **Singular and plural.** `project` is the scoped command; `projects` stays the every-project list rather than becoming a behavior change. The plural is its own `add_parser` with `set_defaults(func=cmd_project, all=True, ...)`, not an argparse alias, because an alias would share the scope flags.
- **Scope precedence** is `_resolve_project`'s: explicit `-p`, then `$ENGRIM_PROJECT`, then the git root or cwd. `--global` is `add --global`'s flag (`-g`, `dest="globl"`) so the spelling matches the write side.
- **The three scopes are an argparse mutually-exclusive group**, the first in the file; it is the honest encoding of `[-p P | --global | --all]` and turns `-p /x --all` into a usage error instead of a silent precedence rule. `prune` resolves the same pair by precedence; happy to match that instead if you prefer one idiom.
- **Empty scopes say so**: `(empty store)` for `--all` and `projects` as before, `(no records for project=/x)` for a scope with nothing, `[]` under `--json`.
- **`--json`** is the existing opt-in flag on `recall`/`list`/`context`/`logs`: one `json.dumps` line, human text by default. Keys are `records`/`active` rather than the SQL alias `n`.
- README gains the `project` and `projects` rows the CLI table was missing; the module docstring gets the matching lines.

## Scope notes

`cmd_projects` becomes `cmd_project` (the body changes anyway) and the `projects` subparser gains `--json`; otherwise additive: one subparser, two README rows, two docstring lines, one test file. Standard library only. No behavior change to `engrim projects`.

## Testing

`python -m pytest` in a venv with the package installed editable and `ENGRIM_EMBED=off`, Python 3.13, macOS: 204 passed (197 before, 7 new). The new tests cover: `--all` lists every project including the global layer; the default follows `$ENGRIM_PROJECT` and `-p` overrides it; `--global` is the user-layer only; the scopes are mutually exclusive; the `--json` list for one project and for `--all`; empty scopes; `projects` produces byte-identical output to `project --all` in text and JSON and rejects `-p`. Also `engrim --help`, `engrim project --help` and `engrim projects --help`.

## AI disclosure

This feature was developed with Claude Code (Anthropic). The design decisions, scope choices, and review/testing direction were mine; I have reviewed the changes and stand behind them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
