### PR TITLE
(fix) Codex setup & integration hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ graph TD
         AGY["Google Antigravity<br/>(PreInvocation & Stop Hooks)"]
         CLAUDE["Claude Code<br/>(SessionStart & Stop Hooks)"]
         CURSOR["Cursor / Windsurf<br/>(Model Context Protocol stdio)"]
-        CODEX["Codex CLI<br/>(Hooks & MCP)"]
+        CODEX["Codex CLI<br/>(Native command hooks)"]
     end
 
     subgraph CoreEngine ["engrim Core Engine (v1.4.1)"]
@@ -64,7 +64,7 @@ graph TD
     AGY <-->|"hook / CLI"| ADAPTERS
     CLAUDE <-->|"hook / CLI"| ADAPTERS
     CURSOR <-->|"JSON-RPC (stdio)"| ADAPTERS
-    CODEX <-->|"hook / MCP"| ADAPTERS
+    CODEX <-->|"command hook"| ADAPTERS
     ADAPTERS --> PROVENANCE
     PROVENANCE --> ROUTER
     ROUTER --> MEMORIES
@@ -94,7 +94,7 @@ engrim setup
 - If `~/.gemini` exists $\rightarrow$ wires Antigravity lifecycle hooks, skill, and MCP server.
 - If `~/.claude` exists $\rightarrow$ wires Claude Code SessionStart, Stop, status line, and CLAUDE.md.
 - If `~/.cursor` exists $\rightarrow$ generates and merges Cursor MCP configuration.
-- If `~/.codex` exists $\rightarrow$ wires Codex CLI hooks and MCP server.
+- If `~/.codex` exists $\rightarrow$ wires Codex CLI native command hooks.
 
 ### Explicit Platform Setup
 
@@ -125,8 +125,11 @@ engrim setup --cursor
 ```bash
 engrim setup --codex
 ```
-- Wires `SessionStart`, `SessionEnd`, `Stop`, and `UserPromptSubmit` hooks in `~/.codex/hooks.json`.
-- Registers the MCP server in `~/.codex/config.toml`.
+- Wires `SessionStart`, `SessionEnd`, `Stop`, and `UserPromptSubmit` command hooks in `~/.codex/hooks.json`.
+- Calls the local `engrim` CLI directly, so MCP is not required. The hooks must be reviewed and trusted
+  with Codex's `/hooks` command before they run.
+- `engrim statusline` accepts Codex-shaped session payloads, but Codex's built-in footer only supports
+  its own status item identifiers, not arbitrary status commands.
 
 #### Windsurf
 Add `engrim` to your `~/.codeium/windsurf/mcp_config.json`:
@@ -267,4 +270,3 @@ Open to collaborations and Staff / Senior engineering opportunities in Agentic A
 ## 12. License
 
 MIT © 2026 Tim Gordon.
-

--- a/src/engrim/cli.py
+++ b/src/engrim/cli.py
@@ -742,12 +742,11 @@ def cmd_assist(conn, a) -> None:
 
 
 def cmd_statusline(conn, a) -> None:
-    """Ambient status line for Claude Code (settings.json `statusLine`). Prints ONE compact line so the
-    user can SEE engrim is live and working for this project — in the status bar, never in the chat. That
-    answers "what did I just install / is this thing even doing anything?" without muddying the exchange
-    or nagging a security-aware user. Reads Claude Code's session JSON on stdin (for the workspace dir),
-    falls back to cwd. Fast + model-free: it only counts rows + reads meta, so it's safe to run on every
-    status refresh."""
+    """Print one compact engrim status line for hosts with a command status-line slot.
+
+    Claude Code invokes this from `settings.json.statusLine`; Codex-shaped hook/session payloads are
+    also accepted so callers can use the same status command when a host exposes a command slot.
+    """
     data, sess = {}, None
     try:
         data = json.load(sys.stdin) or {}
@@ -1124,6 +1123,21 @@ def cmd_hook(conn, a) -> None:
             sys.exit(f"Unknown event {event} for agent {agent}")
         return
 
+    if agent == "codex":
+        # Codex supplies the stable workspace path as `cwd` and expects the same JSON hook output
+        # shape as Claude Code. Do not run Claude's file-memory seed or transcript-directory sweep:
+        # those paths are Claude-specific and would silently point Codex at the wrong store.
+        payload = {}
+        try:
+            payload = json.load(sys.stdin) or {}
+        except Exception:
+            pass
+        a.project = _payload_project(payload, a.project)
+        event = getattr(a, "event", None) or "sessionstart"
+        if event not in ("boot", "sessionstart"):
+            sys.exit(f"Unknown event {event} for agent {agent}")
+        a.no_sync = True
+
     import contextlib
     import io
     # ONE-TIME context build: the very first session for a project seeds the store from Claude
@@ -1482,6 +1496,110 @@ def _setup_cursor(engrim_bin: str, dry_run: bool = False) -> None:
         print(f"✓ registered Cursor MCP entry in {cursor_mcp}")
 
 
+def _codex_home() -> str:
+    """Return the Codex home directory, honoring the same override Codex uses."""
+    return os.path.abspath(os.path.expanduser(os.environ.get("CODEX_HOME") or "~/.codex"))
+
+
+def _codex_hook_commands(engrim_bin: str):
+    """Commands for the Codex-native hook events.
+
+    Codex sends one JSON object on stdin for every command hook. The command hooks deliberately
+    swallow helper failures so a local memory integration can never interrupt the coding session.
+    The hook itself still emits Codex-compatible JSON on the two context-producing events.
+    """
+    return {
+        "SessionStart": (
+            f"{engrim_bin} hook --agent codex --event sessionstart 2>/dev/null || true",
+            20,
+        ),
+        "SessionEnd": (
+            f"{engrim_bin} log --hook --agent codex 2>/dev/null || true",
+            3,
+        ),
+        "Stop": (
+            f"{engrim_bin} log --hook --agent codex 2>/dev/null || true",
+            30,
+        ),
+        "UserPromptSubmit": (
+            f"{engrim_bin} assist 2>/dev/null || true",
+            20,
+        ),
+    }
+
+
+def _setup_codex(engrim_bin: str, dry_run: bool = False) -> None:
+    """Wire Codex to engrim through command hooks.
+
+    MCP is intentionally not part of this path. Codex can run the same local CLI commands as Claude
+    Code, while MCP remains an optional manual integration for users who want model-invoked tools.
+    """
+    print("Wiring Codex CLI environment…")
+    hooks_path = os.path.join(_codex_home(), "hooks.json")
+    commands = _codex_hook_commands(engrim_bin)
+    if dry_run:
+        print(f"[dry-run] Would wire Codex hooks in {hooks_path}")
+        for event, (command, _timeout) in commands.items():
+            print(f"    {event}: {command}")
+        print("[dry-run] Codex hooks must be reviewed and trusted with /hooks before they run")
+        return
+
+    os.makedirs(os.path.dirname(hooks_path), exist_ok=True)
+    hooks_data = {}
+    if os.path.exists(hooks_path):
+        try:
+            with open(hooks_path, "r", encoding="utf-8") as f:
+                hooks_data = json.load(f)
+        except json.JSONDecodeError as e:
+            sys.exit(f"Codex hooks file exists but is not valid JSON ({e}). Fix it, then re-run.")
+        except OSError as e:
+            sys.exit(f"can't read {hooks_path} ({e}). Fix the permissions, then re-run.")
+    if not isinstance(hooks_data, dict):
+        sys.exit(f"Codex hooks file must contain a JSON object: {hooks_path}")
+    hooks = hooks_data.setdefault("hooks", {})
+    if not isinstance(hooks, dict):
+        sys.exit(f"Codex hooks field must be a JSON object: {hooks_path}")
+
+    changed = False
+    for event, (command, timeout) in commands.items():
+        groups = hooks.setdefault(event, [])
+        if not isinstance(groups, list):
+            sys.exit(f"Codex hook event {event} must contain an array: {hooks_path}")
+        managed = []
+        for group in groups:
+            if not isinstance(group, dict):
+                continue
+            handlers = group.get("hooks", [])
+            if not isinstance(handlers, list):
+                continue
+            for handler in handlers:
+                if isinstance(handler, dict) and _cmd_has(handler.get("command", ""), "engrim"):
+                    managed.append(handler)
+        if managed:
+            for handler in managed:
+                desired = {"type": "command", "command": command, "timeout": timeout}
+                if handler != desired:
+                    handler.clear()
+                    handler.update(desired)
+                    changed = True
+            print(f"✓ {event} Codex hook already present in {hooks_path}")
+        else:
+            groups.append({"hooks": [{"type": "command", "command": command, "timeout": timeout}]})
+            changed = True
+            print(f"✓ wired {event} Codex hook\n    {command}")
+
+    if changed:
+        tmp = hooks_path + ".engrim-tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(hooks_data, f, indent=2)
+            f.write("\n")
+        os.replace(tmp, hooks_path)
+        print(f"✓ wired Codex hooks in {hooks_path}")
+    else:
+        print(f"✓ Codex hooks already current in {hooks_path}")
+    print("! review and trust these hooks in Codex with /hooks before they run")
+
+
 def _setup_claude(conn, a, engrim_bin: str, dry_run: bool = False) -> None:
     print("Wiring Claude Code environment…")
     settings_path = os.path.expanduser(getattr(a, "settings", None) or "~/.claude/settings.json")
@@ -1564,7 +1682,7 @@ def _setup_claude(conn, a, engrim_bin: str, dry_run: bool = False) -> None:
 
 
 def cmd_setup(conn, a) -> None:
-    """Universal multi-agent setup: Antigravity, Claude Code, and Cursor."""
+    """Universal multi-agent setup: Antigravity, Claude Code, Cursor, and Codex."""
     engrim_bin = _hook_bin(shutil.which("engrim") or "engrim")
     dry_run = getattr(a, "dry_run", False)
     bin_error = _verify_hook_bin(engrim_bin)
@@ -1574,7 +1692,6 @@ def cmd_setup(conn, a) -> None:
         getattr(a, "claude", False) or
         getattr(a, "cursor", False) or
         getattr(a, "codex", False) or
-        getattr(a, "codex", False) or
         getattr(a, "all", False) or
         getattr(a, "settings", None)
     )
@@ -1583,13 +1700,12 @@ def cmd_setup(conn, a) -> None:
     wire_claude = getattr(a, "claude", False) or getattr(a, "all", False) or bool(getattr(a, "settings", None))
     wire_cursor = getattr(a, "cursor", False) or getattr(a, "all", False)
     wire_codex = getattr(a, "codex", False) or getattr(a, "all", False)
-    wire_codex = getattr(a, "codex", False) or getattr(a, "all", False)
 
     if not explicit:
         gemini_dir = os.path.expanduser("~/.gemini")
         claude_dir = os.path.expanduser("~/.claude")
         cursor_dir = os.path.expanduser("~/.cursor")
-        codex_dir = os.path.expanduser("~/.codex")
+        codex_dir = _codex_home()
         detected = []
         if os.path.isdir(gemini_dir):
             wire_agy = True
@@ -1645,7 +1761,7 @@ def cmd_setup(conn, a) -> None:
         else:
             print("• semantic recall unavailable (model2vec didn't load) — running pure-lexical for now")
 
-    if wire_claude and bin_error and not dry_run:
+    if (wire_claude or wire_codex) and bin_error and not dry_run:
         sys.stdout.flush()
         sys.exit(f"\nNOT done — the hooks are written, but `{engrim_bin} --help` fails in a shell "
                  f"({bin_error}),\nso every one of them will silently do nothing. Fix that and "
@@ -1654,18 +1770,22 @@ def cmd_setup(conn, a) -> None:
     if wire_claude and not dry_run:
         print("\nDone. Open a NEW Claude Code session (or run /hooks to reload) and your project "
               "memory will auto-load. Try: engrim add -t fact -s \"hello world\" ; engrim context")
+    if wire_codex and not dry_run:
+        print("\nCodex hooks are installed. Open Codex and use /hooks to review and trust them; "
+              "memory will load on the next session.")
 
     print("\nUniversal memory setup complete.")
 
 
 
 def cmd_uninstall(conn, a) -> None:
-    """Universal multi-agent uninstall: Antigravity, Claude Code, and Cursor."""
+    """Universal multi-agent uninstall: Antigravity, Claude Code, Cursor, and Codex."""
     dry_run = getattr(a, "dry_run", False)
     explicit = bool(
         getattr(a, "agy", False) or
         getattr(a, "claude", False) or
         getattr(a, "cursor", False) or
+        getattr(a, "codex", False) or
         getattr(a, "all", False) or
         getattr(a, "settings", None)
     )
@@ -1673,12 +1793,13 @@ def cmd_uninstall(conn, a) -> None:
     wire_agy = getattr(a, "agy", False) or getattr(a, "all", False)
     wire_claude = getattr(a, "claude", False) or getattr(a, "all", False) or bool(getattr(a, "settings", None))
     wire_cursor = getattr(a, "cursor", False) or getattr(a, "all", False)
+    wire_codex = getattr(a, "codex", False) or getattr(a, "all", False)
 
     if not explicit:
         gemini_dir = os.path.expanduser("~/.gemini")
         claude_dir = os.path.expanduser("~/.claude")
         cursor_dir = os.path.expanduser("~/.cursor")
-        codex_dir = os.path.expanduser("~/.codex")
+        codex_dir = _codex_home()
         detected = []
         if os.path.isdir(gemini_dir):
             wire_agy = True
@@ -1826,6 +1947,69 @@ def _uninstall_claude(a, dry_run: bool = False) -> None:
             print(f"✓ unwired hooks and status line from {settings_path}")
         else:
             print(f"✓ hooks and status line already unwired from {settings_path}")
+
+
+def _uninstall_codex(dry_run: bool = False) -> None:
+    """Remove only the command hooks that setup owns; leave Codex config and MCP untouched."""
+    print("Unwiring Codex CLI environment…")
+    hooks_path = os.path.join(_codex_home(), "hooks.json")
+    if dry_run:
+        print(f"[dry-run] Would unwire Codex hooks in {hooks_path}")
+        return
+    if not os.path.exists(hooks_path):
+        print(f"✓ Codex hooks already unwired from {hooks_path}")
+        return
+
+    try:
+        with open(hooks_path, "r", encoding="utf-8") as f:
+            hooks_data = json.load(f)
+    except json.JSONDecodeError as e:
+        sys.exit(f"Codex hooks file exists but is not valid JSON ({e}). Fix it, then re-run.")
+    if not isinstance(hooks_data, dict):
+        sys.exit(f"Codex hooks file must contain a JSON object: {hooks_path}")
+    hooks = hooks_data.get("hooks", {})
+    if not isinstance(hooks, dict):
+        sys.exit(f"Codex hooks field must be a JSON object: {hooks_path}")
+    changed = False
+    for event in ("SessionStart", "SessionEnd", "Stop", "UserPromptSubmit"):
+        groups = hooks.get(event)
+        if not isinstance(groups, list):
+            continue
+        new_groups = []
+        for group in groups:
+            if not isinstance(group, dict):
+                new_groups.append(group)
+                continue
+            handlers = group.get("hooks", [])
+            if not isinstance(handlers, list):
+                new_groups.append(group)
+                continue
+            new_handlers = [
+                handler for handler in handlers
+                if not (isinstance(handler, dict) and _cmd_has(handler.get("command", ""), "engrim"))
+            ]
+            if len(new_handlers) != len(handlers):
+                changed = True
+            if new_handlers:
+                group["hooks"] = new_handlers
+                new_groups.append(group)
+            else:
+                changed = True
+        if new_groups:
+            hooks[event] = new_groups
+        elif event in hooks:
+            del hooks[event]
+            changed = True
+
+    if changed:
+        tmp = hooks_path + ".engrim-tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(hooks_data, f, indent=2)
+            f.write("\n")
+        os.replace(tmp, hooks_path)
+        print(f"✓ unwired Codex hooks from {hooks_path}")
+    else:
+        print(f"✓ Codex hooks already unwired from {hooks_path}")
 
 
 _IMPORT_TYPE_MAP = {
@@ -2431,6 +2615,37 @@ def _ingest_transcript(conn, project, path, session=None, include_thinking=False
     return added
 
 
+def _log_codex_hook(conn, payload, explicit_project="auto"):
+    """Capture the stable prompt/assistant fields Codex exposes to command hooks.
+
+    Codex documents `transcript_path` as a convenience only and does not promise its file format.
+    Logging the event payload keeps the integration useful without coupling it to that private file.
+    """
+    event = payload.get("hook_event_name") or payload.get("event")
+    if event == "UserPromptSubmit":
+        role = "user"
+        content = payload.get("prompt") or ""
+    elif event == "Stop":
+        role = "assistant"
+        content = payload.get("last_assistant_message") or ""
+    else:
+        return
+    if not content:
+        return
+
+    project = _payload_project(payload, explicit_project)
+    session = payload.get("session_id")
+    turn = payload.get("turn_id")
+    identity = turn or hashlib.sha256(content.encode("utf-8")).hexdigest()[:16]
+    msg_uuid = f"codex:{session or 'session'}:{event}:{identity}"
+    conn.execute(
+        "INSERT OR IGNORE INTO log(ts,project,session,role,content,raw,msg_uuid) "
+        "VALUES(?,?,?,?,?,?,?)",
+        (_now(), project, session, role, content, json.dumps(payload, ensure_ascii=False), msg_uuid),
+    )
+    conn.commit()
+
+
 def cmd_log(conn, a) -> None:
     """Append to the raw transcript log. `--hook` reads a Stop-hook JSON from stdin and ingests the
     session's new turns; `--from-transcript PATH` ingests a file; otherwise append one -r/-c turn."""
@@ -2438,6 +2653,9 @@ def cmd_log(conn, a) -> None:
         try:
             payload = json.load(sys.stdin)
         except Exception:
+            return
+        if getattr(a, "agent", "claude") == "codex":
+            _log_codex_hook(conn, payload, a.project)
             return
         # Resolve from the session's STABLE launch dir, not the hook process's os.getcwd(). A Stop
         # hook can be spawned with an incidental cwd (e.g. it inherits one a tool subprocess chdir'd
@@ -3013,13 +3231,13 @@ def build_parser() -> argparse.ArgumentParser:
     pc.add_argument("--json", action="store_true")
     pc.set_defaults(func=cmd_context)
 
-    ph = sub.add_parser("hook", help="Lifecycle hook JSON for Claude Code / Antigravity")
+    ph = sub.add_parser("hook", help="Lifecycle hook JSON for Claude Code / Antigravity / Codex")
     ph.add_argument("-p", "--project", default="auto")
     ph.add_argument("-b", "--budget", type=int, default=4000)
     ph.add_argument("--no-sync", action="store_true",
                     help="don't mirror Claude Code's file-memory before injecting")
-    ph.add_argument("--agent", choices=["claude", "agy", "antigravity"], default="claude",
-                    help="Target agent environment (default: claude)")
+    ph.add_argument("--agent", choices=["claude", "agy", "antigravity", "codex"], default="claude",
+                     help="Target agent environment (default: claude)")
     ph.add_argument("--event", choices=["boot", "stop", "sessionstart"], default=None,
                     help="Hook lifecycle event (default: boot or sessionstart)")
     ph.add_argument("--strict", "--gate", dest="strict", action="store_true",
@@ -3039,7 +3257,7 @@ def build_parser() -> argparse.ArgumentParser:
     prt.add_argument("--json", action="store_true")
     prt.set_defaults(func=cmd_retire)
 
-    pse = sub.add_parser("setup", help="wire engrim into agent environments (Antigravity, Claude, Cursor)")
+    pse = sub.add_parser("setup", help="wire engrim into agent environments (Antigravity, Claude, Cursor, Codex)")
     pse.add_argument("--agy", "--antigravity", dest="agy", action="store_true",
                      help="wire Antigravity hooks, deploy skill, and register MCP server")
     pse.add_argument("--claude", dest="claude", action="store_true",
@@ -3049,7 +3267,7 @@ def build_parser() -> argparse.ArgumentParser:
     pse.add_argument("--cursor", dest="cursor", action="store_true",
                      help="add engrim MCP entry to Cursor mcp.json")
     pse.add_argument("--codex", dest="codex", action="store_true",
-                     help="wire Codex CLI hooks and MCP")
+                     help="wire Codex CLI command hooks (MCP is optional and not required)")
     pse.add_argument("--all", dest="all", action="store_true",
                      help="configure all detected agent environments")
     pse.add_argument("--dry-run", action="store_true",
@@ -3059,7 +3277,7 @@ def build_parser() -> argparse.ArgumentParser:
     pse.add_argument("--no-claude-md", action="store_true", help="don't touch ~/.claude/CLAUDE.md")
     pse.set_defaults(func=cmd_setup)
 
-    pun = sub.add_parser("uninstall", help="remove engrim from agent environments (Antigravity, Claude, Cursor)")
+    pun = sub.add_parser("uninstall", help="remove engrim from agent environments (Antigravity, Claude, Cursor, Codex)")
     pun.add_argument("--agy", "--antigravity", dest="agy", action="store_true",
                      help="remove Antigravity hooks, skill, and MCP server")
     pun.add_argument("--claude", dest="claude", action="store_true",
@@ -3120,6 +3338,8 @@ def build_parser() -> argparse.ArgumentParser:
     plog.add_argument("--from-transcript", help="ingest new turns from a Claude Code transcript JSONL")
     plog.add_argument("--hook", action="store_true",
                       help="read a Stop-hook JSON from stdin and ingest the session's new turns")
+    plog.add_argument("--agent", choices=["claude", "codex"], default="claude",
+                      help="hook payload source (default: claude)")
     plog.add_argument("--reindex", action="store_true",
                       help="re-derive searchable text from the raw turns already stored (recovers "
                            "action lines for history logged before they existed)")
@@ -3136,7 +3356,7 @@ def build_parser() -> argparse.ArgumentParser:
                      help="char budget for the injected slice (default 600 ≈ ~150 tokens)")
     pas.set_defaults(func=cmd_assist)
 
-    psl = sub.add_parser("statusline", help="one-line ambient status for Claude Code's status bar")
+    psl = sub.add_parser("statusline", help="one-line ambient engrim status for a host status bar")
     psl.add_argument("-p", "--project", default="auto")
     psl.set_defaults(func=cmd_statusline)
 

--- a/tests/test_codex_setup.py
+++ b/tests/test_codex_setup.py
@@ -1,0 +1,159 @@
+"""Regression tests for the Codex CLI setup and hook integration."""
+import io
+import json
+import sqlite3
+
+import engrim.cli as cli
+from engrim.cli import main
+
+
+def _codex_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    codex = home / ".codex"
+    codex.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    monkeypatch.setenv("CODEX_HOME", str(codex))
+    return codex
+
+
+def _run_codex_setup(tmp_path, monkeypatch, which="/opt/my tools/bin/engrim"):
+    codex = _codex_home(tmp_path, monkeypatch)
+    monkeypatch.setattr(cli.shutil, "which", lambda _name: which)
+    monkeypatch.setattr(cli, "_verify_hook_bin", lambda _bin: None)
+    db = tmp_path / "memory.db"
+    main(["--db", str(db), "setup", "--codex"])
+    return db, codex
+
+
+def test_setup_codex_writes_codex_native_hooks_without_requiring_mcp(tmp_path, monkeypatch, capsys):
+    db, codex = _run_codex_setup(tmp_path, monkeypatch)
+    out = capsys.readouterr().out
+
+    hooks_path = codex / "hooks.json"
+    hooks = json.loads(hooks_path.read_text(encoding="utf-8"))
+    assert set(hooks["hooks"]) == {"SessionStart", "SessionEnd", "Stop", "UserPromptSubmit"}
+    commands = {
+        event: group["hooks"][0]["command"]
+        for event, groups in hooks["hooks"].items()
+        for group in groups
+    }
+    assert '"/opt/my tools/bin/engrim" hook --agent codex --event sessionstart' in commands["SessionStart"]
+    assert '"/opt/my tools/bin/engrim" assist' in commands["UserPromptSubmit"]
+    assert '"/opt/my tools/bin/engrim" log --hook --agent codex' in commands["Stop"]
+    assert '"/opt/my tools/bin/engrim" log --hook --agent codex' in commands["SessionEnd"]
+    assert "✓ wired Codex hooks" in out
+    assert "review and trust" in out
+    assert not (codex / "config.toml").exists()
+    assert db.exists()
+
+
+def test_setup_codex_preserves_existing_config_and_is_idempotent(tmp_path, monkeypatch, capsys):
+    codex = _codex_home(tmp_path, monkeypatch)
+    config_path = codex / "config.toml"
+    config_path.write_text(
+        'model = "gpt-5.6"\n\n[mcp_servers.keep]\ncommand = "keep-me"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(cli.shutil, "which", lambda _name: "/usr/local/bin/engrim")
+    monkeypatch.setattr(cli, "_verify_hook_bin", lambda _bin: None)
+    db = tmp_path / "memory.db"
+
+    main(["--db", str(db), "setup", "--codex"])
+    first_hooks = (codex / "hooks.json").read_text(encoding="utf-8")
+    first_config = config_path.read_text(encoding="utf-8")
+    main(["--db", str(db), "setup", "--codex"])
+    capsys.readouterr()
+
+    assert (codex / "hooks.json").read_text(encoding="utf-8") == first_hooks
+    assert config_path.read_text(encoding="utf-8") == first_config
+    assert first_config == 'model = "gpt-5.6"\n\n[mcp_servers.keep]\ncommand = "keep-me"\n'
+
+
+def test_codex_session_start_uses_payload_cwd_and_emits_context(tmp_path, monkeypatch, capsys):
+    _codex_home(tmp_path, monkeypatch)
+    project = tmp_path / "workspace"
+    project.mkdir()
+    main(["--db", str(tmp_path / "memory.db"), "add", "-p", str(project), "-t", "fact",
+          "-s", "Codex project memory is available"])
+    capsys.readouterr()
+
+    payload = {"cwd": str(project), "hook_event_name": "SessionStart", "source": "startup"}
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO(json.dumps(payload)))
+    main(["--db", str(tmp_path / "memory.db"), "hook", "--agent", "codex",
+          "--event", "sessionstart", "--no-sync"])
+    result = json.loads(capsys.readouterr().out)
+    assert result["hookSpecificOutput"]["hookEventName"] == "SessionStart"
+    assert "Codex project memory is available" in result["hookSpecificOutput"]["additionalContext"]
+
+
+def test_codex_prompt_and_stop_hooks_log_once(tmp_path, monkeypatch, capsys):
+    _codex_home(tmp_path, monkeypatch)
+    project = tmp_path / "workspace"
+    project.mkdir()
+    prompt = {
+        "cwd": str(project),
+        "hook_event_name": "UserPromptSubmit",
+        "session_id": "session-1",
+        "turn_id": "turn-1",
+        "prompt": "We decided to keep the SQLite memory store.",
+    }
+    stop = {
+        "cwd": str(project),
+        "hook_event_name": "Stop",
+        "session_id": "session-1",
+        "turn_id": "turn-1",
+        "last_assistant_message": "The SQLite memory store remains the selected design.",
+    }
+    for payload in (prompt, prompt, stop, stop):
+        monkeypatch.setattr(cli.sys, "stdin", io.StringIO(json.dumps(payload)))
+        args = ["--db", str(tmp_path / "memory.db"), "log", "--hook", "--agent", "codex"]
+        main(args)
+        capsys.readouterr()
+
+    conn = sqlite3.connect(tmp_path / "memory.db")
+    rows = conn.execute("SELECT role, content FROM log ORDER BY id").fetchall()
+    assert rows == [
+        ("user", "We decided to keep the SQLite memory store."),
+        ("assistant", "The SQLite memory store remains the selected design."),
+    ]
+
+
+def test_statusline_reads_codex_payload(tmp_path, monkeypatch, capsys):
+    _codex_home(tmp_path, monkeypatch)
+    project = tmp_path / "workspace"
+    project.mkdir()
+    db = tmp_path / "memory.db"
+    main(["--db", str(db), "add", "-p", str(project), "-t", "fact", "-s", "status is live"])
+    capsys.readouterr()
+
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO(json.dumps({
+        "cwd": str(project),
+        "session_id": "session-1",
+    })))
+    main(["--db", str(db), "statusline"])
+    out = capsys.readouterr().out
+    assert "engrim" in out
+    assert "curated" in out
+
+
+def test_uninstall_codex_preserves_unrelated_hooks_and_config(tmp_path, monkeypatch, capsys):
+    db, codex = _run_codex_setup(tmp_path, monkeypatch)
+    hooks_path = codex / "hooks.json"
+    hooks = json.loads(hooks_path.read_text(encoding="utf-8"))
+    hooks["hooks"]["Stop"].append({"hooks": [{"type": "command", "command": "keep-me"}]})
+    hooks_path.write_text(json.dumps(hooks), encoding="utf-8")
+    config_path = codex / "config.toml"
+    config_path.write_text('[mcp_servers.keep]\ncommand = "keep-me"\n', encoding="utf-8")
+    original_config = config_path.read_text(encoding="utf-8")
+
+    main(["--db", str(db), "uninstall", "--codex"])
+    capsys.readouterr()
+    remaining_hooks = json.loads(hooks_path.read_text(encoding="utf-8"))
+    assert all(
+        h.get("command") == "keep-me"
+        for groups in remaining_hooks["hooks"].values()
+        for group in groups
+        for h in group.get("hooks", [])
+    )
+    assert config_path.read_text(encoding="utf-8") == original_config


### PR DESCRIPTION
## Summary

Using engrim 1.4.1, `engrim setup --codex` did not work. 
This PR attempts to fix the Codex integration by using native Codex command hooks (and does not explicitly) require the use of an MCP).

```
# install
uv tool install --upgrade engrim
# version
engrim -v
engrim 1.4.1

# setup
engrim setup --codex
Traceback (most recent call last):
  File "/Users/t31m/.local/bin/engrim", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "/Users/t31m/.local/share/uv/tools/engrim/lib/python3.14/site-packages/engrim/cli.py", line 3250, in main
    args.func(conn, args)
    ~~~~~~~~~^^^^^^^^^^^^
  File "/Users/t31m/.local/share/uv/tools/engrim/lib/python3.14/site-packages/engrim/cli.py", line 1621, in cmd_setup
    _setup_codex(engrim_bin, dry_run=dry_run)
    ^^^^^^^^^^^^
NameError: name '_setup_codex' is not defined. Did you mean: '_setup_claude'?
```

  ### Changes

- Implement engrim setup --codex.
- Add hooks for:
    - SessionStart
    - UserPromptSubmit
    - Stop
    - SessionEnd

- Support Codex payloads for:
    - Session context injection
    - Prompt and assistant logging
    - Duplicate suppression
    - Project resolution via cwd

- Preserve unrelated Codex hooks and configuration.
- Make setup idempotent and add Codex uninstall support.
- Update documentation and add Codex-specific regression tests.
- Support engrim statusline with Codex-shaped payloads.

Codex’s built-in footer only supports its own status identifiers, so this change does not add an unsupported custom status command to Codex configuration. The standalone engrim statusline command remains available for hosts that support command-based  statuslines.

## Verification

- Focused Codex tests: 6 passed
- Full test suite: 233 passed
- End-to-end CLI smoke test passed for setup, add, recall, hooks, logging, deduplication, and statusline
- Confirmed MCP configuration remains untouched

 After setup, Codex hooks must be reviewed and trusted with /hooks.

The code for this PR was created using Codex - GPT 5.6 Luna (xhigh)