### PR TITLE
feat(mcp): advertise outputSchema on all four tools

### DIFF
--- a/src/engrim/mcp_server.py
+++ b/src/engrim/mcp_server.py
@@ -55,6 +55,16 @@ TOOLS = [
             },
             "required": ["query"],
         },
+        "outputSchema": {
+            "type": "object",
+            "description": "Ranked memory records matching the query.",
+            "properties": {
+                "project": {"type": "string"},
+                "count": {"type": "integer"},
+                "records": {"type": "array", "items": {"type": "object"}},
+            },
+            "required": ["project", "count", "records"],
+        },
     },
     {
         "name": "engrim_context",
@@ -72,6 +82,18 @@ TOOLS = [
                            "description": "Maximum character budget for the returned memory pack (default 4000). Prioritizes active decisions and constraints."},
             },
             "required": [],
+        },
+        "outputSchema": {
+            "type": "object",
+            "description": "Curated session-boot pack within the character budget.",
+            "properties": {
+                "project": {"type": "string"},
+                "loaded": {"type": "integer"},
+                "total_active": {"type": "integer"},
+                "chars": {"type": "integer"},
+                "records": {"type": "array", "items": {"type": "object"}},
+            },
+            "required": ["project", "loaded", "total_active", "chars", "records"],
         },
     },
     {
@@ -100,6 +122,18 @@ TOOLS = [
             },
             "required": ["type", "summary"],
         },
+        "outputSchema": {
+            "type": "object",
+            "description": "Confirmation identifying the stored record.",
+            "properties": {
+                "id": {"type": "integer"},
+                "type": {"type": "string"},
+                "project": {"type": "string"},
+                "summary": {"type": "string"},
+                "origin_agent": {"type": "string"},
+            },
+            "required": ["id", "type", "project", "summary", "origin_agent"],
+        },
     },
     {
         "name": "engrim_review",
@@ -113,6 +147,21 @@ TOOLS = [
                             "description": "Project identifier tag; 'auto' infers from current working directory repository root."},
             },
             "required": [],
+        },
+        "outputSchema": {
+            "type": "object",
+            "description": "Coverage verdict plus uncaptured decision candidates (safe_to_clear is null when no transcript log exists).",
+            "properties": {
+                "project": {"type": "string"},
+                "total_log_turns": {"type": "integer"},
+                "scanned_turns": {"type": "integer"},
+                "active_curated": {"type": "integer"},
+                "safe_to_clear": {"type": ["boolean", "null"]},
+                "uncaptured_count": {"type": "integer"},
+                "uncaptured": {"type": "array", "items": {"type": "object"}},
+                "message": {"type": "string"},
+            },
+            "required": ["project", "total_log_turns", "scanned_turns", "active_curated", "safe_to_clear", "uncaptured_count", "uncaptured", "message"],
         },
     },
 ]

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -36,6 +36,18 @@ def test_initialize_and_tools_list(tmp_path):
     assert {t["name"] for t in TOOLS} == names
 
 
+def test_tools_list_output_schemas():
+    # Every tool must advertise an outputSchema so clients can validate
+    # structured results without guessing shapes.
+    for tool in TOOLS:
+        schema = tool.get("outputSchema")
+        assert isinstance(schema, dict), f"Tool {tool['name']} is missing outputSchema"
+        assert schema.get("type") in ("object", "array", "string"), \
+            f"Tool {tool['name']} has unexpected outputSchema type"
+        assert isinstance(schema.get("description"), str), \
+            f"Tool {tool['name']} outputSchema is missing a description"
+
+
 def test_add_then_recall_and_context(tmp_path):
     db = str(tmp_path / "m.db")
     conn = connect(db)


### PR DESCRIPTION
Issues are disabled on this repo, so filing directly as a PR: all four MCP tools now advertise outputSchema mirroring the handler payloads (recall/context/review objects, add confirmation record). Proof: full suite green (234 passed, incl. new test_tools_list_output_schemas), live tools/list graded 4/4 schemas by an independent stdio JSON-RPC probe (was 4/4 docs, 0/4 schemas).